### PR TITLE
ci: Fix Makefile target dependencies and extend simutils.py

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
   # Simulate SW on Snitch Cluster w/ Verilator #
   ##############################################
 
-  sw-snitch-cluster:
+  sw-snitch-cluster-vlt:
     name: Simulate SW on Snitch Cluster w/ Verilator
     runs-on: ubuntu-22.04
     container:
@@ -45,3 +45,20 @@ jobs:
         run: |-
           ./sw/tests/run.py sw/tests/passing-apps.list --simulator verilator
           ./sw/apps/run.py sw/apps/passing-apps.list --simulator verilator
+
+  ############################################
+  # Build SW on Snitch Cluster w/ Banshee #
+  ############################################
+
+  sw-snitch-cluster-banshee:
+    name: Build SW on Snitch Cluster w/ Banshee
+    runs-on: ubuntu-22.04
+    container:
+      image: ghcr.io/pulp-platform/snitch_cluster
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: 'recursive'
+      - name: Build Software
+        run: |
+          make -C target/snitch_cluster SELECT_RUNTIME=banshee sw

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -78,7 +78,7 @@ snitch-cluster-vlt:
   script:
     - cd target/snitch_cluster
     - $VERILATOR make bin/snitch_cluster.vlt
-    - $VERILATOR ./sw/test/run.py sw/tests/passing-apps.list --simulator verilator
+    - $VERILATOR ./sw/tests/run.py sw/tests/passing-apps.list --simulator verilator
     - $VERILATOR ./sw/apps/run.py sw/apps/passing-apps.list --simulator verilator
   # yamllint enable rule:line-length
 
@@ -88,7 +88,7 @@ snitch-cluster-vcs:
   script:
     - cd target/snitch_cluster
     - $VCS make bin/snitch_cluster.vcs
-    - $VCS ./sw/test/run.py sw/tests/passing-apps.list --simulator vcs
+    - $VCS ./sw/tests/run.py sw/tests/passing-apps.list --simulator vcs
     - $VCS ./sw/apps/run.py sw/apps/passing-apps.list --simulator vcs
 
 # Questa
@@ -97,5 +97,5 @@ snitch-cluster-vsim:
   script:
     - cd target/snitch_cluster
     - $QUESTA make bin/snitch_cluster.vsim
-    - $QUESTA ./sw/test/run.py sw/tests/passing-apps.list --simulator vsim
+    - $QUESTA ./sw/tests/run.py sw/tests/passing-apps.list --simulator vsim
     - $QUESTA ./sw/apps/run.py sw/apps/passing-apps.list --simulator vsim

--- a/target/common/common.mk
+++ b/target/common/common.mk
@@ -24,7 +24,6 @@ TB_SRCS   := $(wildcard ${ROOT}/hw/ip/test/*.sv)
 TB_DIR    := ${ROOT}/target/common/test
 
 VSIM_BENDER   += -t test -t rtl -t simulation -t vsim
-VSIM_SOURCES   = $(shell ${BENDER} script flist ${VSIM_BENDER} | ${SED_SRCS})
 VSIM_BUILDDIR := work-vsim
 
 # fesvr is being installed here
@@ -44,7 +43,6 @@ VLT_FLAGS    += -Wno-UNOPTFLAT
 VLT_FLAGS    += -Wno-fatal
 VLT_FLAGS    += --unroll-count 1024
 VLT_BENDER   += -t rtl
-VLT_SOURCES  := $(shell ${BENDER} script flist ${VLT_BENDER} | ${SED_SRCS})
 VLT_CFLAGS   += -std=c++14 -pthread
 VLT_CFLAGS   +=-I ${VLT_BUILDDIR} -I $(VLT_ROOT)/include -I $(VLT_ROOT)/include/vltstd -I $(VLT_FESVR)/include -I $(TB_DIR)
 

--- a/target/common/common.mk
+++ b/target/common/common.mk
@@ -26,6 +26,11 @@ TB_DIR    := ${ROOT}/target/common/test
 VSIM_BENDER   += -t test -t rtl -t simulation -t vsim
 VSIM_BUILDDIR := work-vsim
 
+# VCS_BUILDDIR should to be the same as the `DEFAULT : ./work-vcs`
+# in target/snitch_cluster/synopsys_sim.setup
+VCS_BENDER   += -t test -t rtl -t simulation -t vcs
+VCS_BUILDDIR := work-vcs
+
 # fesvr is being installed here
 FESVR          ?= ${MKFILE_DIR}work
 FESVR_VERSION  ?= 35d50bc40e59ea1d5566fbd3d9226023821b1bb6
@@ -159,11 +164,11 @@ endef
 #######
 # VCS #
 #######
-work-vcs/compile.sh: ${VSIM_SOURCES} ${TB_SRCS}
-	mkdir -p work-vcs
-	${BENDER} script vcs ${VSIM_BENDER} --vlog-arg="${VLOGAN_FLAGS}" --vcom-arg="${VHDLAN_FLAGS}" > $@
+$(VCS_BUILDDIR)/compile.sh:
+	mkdir -p $(VCS_BUILDDIR)
+	${BENDER} script vcs ${VCS_BENDER} --vlog-arg="${VLOGAN_FLAGS}" --vcom-arg="${VHDLAN_FLAGS}" > $@
 	chmod +x $@
-	$@ > work-vcs/compile.log
+	$@ > $(VCS_BUILDDIR)/compile.log
 
 ########
 # Util #

--- a/target/common/common.mk
+++ b/target/common/common.mk
@@ -24,17 +24,21 @@ TB_SRCS   := $(wildcard ${ROOT}/hw/ip/test/*.sv)
 TB_DIR    := ${ROOT}/target/common/test
 
 VSIM_BENDER   += -t test -t rtl -t simulation -t vsim
+VSIM_SOURCES   = $(shell ${BENDER} script flist ${VSIM_BENDER} | ${SED_SRCS})
 VSIM_BUILDDIR := work-vsim
 
 # VCS_BUILDDIR should to be the same as the `DEFAULT : ./work-vcs`
 # in target/snitch_cluster/synopsys_sim.setup
 VCS_BENDER   += -t test -t rtl -t simulation -t vcs
+VCS_SOURCES   = $(shell ${BENDER} script flist ${VCS_BENDER} | ${SED_SRCS})
 VCS_BUILDDIR := work-vcs
 
 # fesvr is being installed here
 FESVR          ?= ${MKFILE_DIR}work
 FESVR_VERSION  ?= 35d50bc40e59ea1d5566fbd3d9226023821b1bb6
 
+VLT_BENDER   += -t rtl
+VLT_SOURCES   = $(shell ${BENDER} script flist ${VLT_BENDER} | ${SED_SRCS})
 VLT_BUILDDIR := work-vlt
 VLT_FESVR     = $(VLT_BUILDDIR)/riscv-isa-sim
 VLT_FLAGS    += -Wno-BLKANDNBLK
@@ -47,7 +51,6 @@ VLT_FLAGS    += -Wno-UNSIGNED
 VLT_FLAGS    += -Wno-UNOPTFLAT
 VLT_FLAGS    += -Wno-fatal
 VLT_FLAGS    += --unroll-count 1024
-VLT_BENDER   += -t rtl
 VLT_CFLAGS   += -std=c++14 -pthread
 VLT_CFLAGS   +=-I ${VLT_BUILDDIR} -I $(VLT_ROOT)/include -I $(VLT_ROOT)/include/vltstd -I $(VLT_FESVR)/include -I $(TB_DIR)
 

--- a/target/snitch_cluster/Makefile
+++ b/target/snitch_cluster/Makefile
@@ -66,10 +66,6 @@ VSIM_BENDER += -t snitch_cluster
 VLT_BENDER  += -t snitch_cluster
 VCS_BENDER  += -t snitch_cluster
 
-VLT_SOURCES  := $(shell ${BENDER} script flist ${VLT_BENDER} | ${SED_SRCS})
-VSIM_SOURCES := $(shell ${BENDER} script flist ${VSIM_BENDER} | ${SED_SRCS})
-VCS_SOURCES  := $(shell ${BENDER} script flist ${VCS_BENDER} | ${SED_SRCS})
-
 QUESTA_64BIT = -64
 VLOG_64BIT   = -64
 

--- a/target/snitch_cluster/Makefile
+++ b/target/snitch_cluster/Makefile
@@ -233,14 +233,14 @@ bin/snitch_cluster.vlt: $(VLT_AR) $(VLT_COBJ) ${VLT_BUILDDIR}/lib/libfesvr.a
 clean-vsim: clean-work
 	rm -rf bin/snitch_cluster.vsim bin/snitch_cluster.vsim.gui $(VSIM_BUILDDIR) vsim.wlf
 
-${VSIM_BUILDDIR}/compile.vsim.tcl: $(VSIM_SOURCES) ${TB_SRCS} ${TB_CC_SOURCES}
+${VSIM_BUILDDIR}/compile.vsim.tcl:
 	vlib $(dir $@)
 	${BENDER} script vsim ${VSIM_BENDER} --vlog-arg="${VLOG_FLAGS} -work $(dir $@) " > $@
 	echo '${VLOG} -work $(dir $@) ${TB_CC_SOURCES} -ccflags "$(TB_CC_FLAGS)"' >> $@
 	echo 'return 0' >> $@
 
 # Build compilation script and compile all sources for Questasim simulation
-bin/snitch_cluster.vsim: ${VSIM_BUILDDIR}/compile.vsim.tcl work/lib/libfesvr.a
+bin/snitch_cluster.vsim: ${VSIM_BUILDDIR}/compile.vsim.tcl $(VSIM_SOURCES) ${TB_SRCS} ${TB_CC_SOURCES} work/lib/libfesvr.a
 	$(call QUESTASIM,tb_bin)
 
 #######
@@ -254,11 +254,11 @@ clean-vcs: clean-work
 	rm -rf bin/snitch_cluster.vcs $(VCS_BUILDDIR) vc_hdrs.h
 
 # Build compilation script and compile all sources for VCS simulation
-bin/snitch_cluster.vcs: ${VCS_SOURCES} ${TB_SRCS} $(VCS_BUILDDIR)/compile.sh work/lib/libfesvr.a $(GENERATED_DIR)/snitch_cluster_wrapper.sv ${TB_DIR}/common_lib.cc $(GENERATED_DIR)/bootdata.cc
+bin/snitch_cluster.vcs: ${VCS_SOURCES} ${TB_SRCS} $(TB_CC_SOURCES) $(VCS_BUILDDIR)/compile.sh work/lib/libfesvr.a
 	mkdir -p bin
 	vcs -Mlib=$(VCS_BUILDDIR) -Mdir=$(VCS_BUILDDIR) -o bin/snitch_cluster.vcs -cc $(CC) -cpp $(CXX) \
-		-assert disable_cover -override_timescale=1ns/1ps -full64 tb_bin ${TB_DIR}/rtl_lib.cc ${TB_DIR}/common_lib.cc $(GENERATED_DIR)/bootdata.cc \
-		-CFLAGS "-std=c++14 -I${MKFILE_DIR} -I${MKFILE_DIR}/test -I${FESVR}/include -I${TB_DIR}" -LDFLAGS "-L${FESVR}/lib" -lfesvr
+		-assert disable_cover -override_timescale=1ns/1ps -full64 tb_bin $(TB_CC_SRCS) \
+		-CFLAGS $(TB_CC_FLAGS) -LDFLAGS "-L${FESVR}/lib" -lfesvr
 
 ##########
 # Traces #

--- a/target/snitch_cluster/Makefile
+++ b/target/snitch_cluster/Makefile
@@ -64,9 +64,11 @@ CFG         = cfg/lru.hjson
 
 VSIM_BENDER += -t snitch_cluster
 VLT_BENDER  += -t snitch_cluster
+VCS_BENDER  += -t snitch_cluster
 
 VLT_SOURCES  := $(shell ${BENDER} script flist ${VLT_BENDER} | ${SED_SRCS})
 VSIM_SOURCES := $(shell ${BENDER} script flist ${VSIM_BENDER} | ${SED_SRCS})
+VCS_SOURCES  := $(shell ${BENDER} script flist ${VCS_BENDER} | ${SED_SRCS})
 
 QUESTA_64BIT = -64
 VLOG_64BIT   = -64
@@ -249,12 +251,12 @@ bin/snitch_cluster.vsim: ${VSIM_BUILDDIR}/compile.vsim.tcl work/lib/libfesvr.a
 
 # Clean all build directories and temporary files for VCS simulation
 clean-vcs: clean-work
-	rm -rf bin/snitch_cluster.vcs work-vcs
+	rm -rf bin/snitch_cluster.vcs $(VCS_BUILDDIR) vc_hdrs.h
 
 # Build compilation script and compile all sources for VCS simulation
-bin/snitch_cluster.vcs: work-vcs/compile.sh work/lib/libfesvr.a $(GENERATED_DIR)/snitch_cluster_wrapper.sv ${TB_DIR}/common_lib.cc $(GENERATED_DIR)/bootdata.cc
+bin/snitch_cluster.vcs: ${VCS_SOURCES} ${TB_SRCS} $(VCS_BUILDDIR)/compile.sh work/lib/libfesvr.a $(GENERATED_DIR)/snitch_cluster_wrapper.sv ${TB_DIR}/common_lib.cc $(GENERATED_DIR)/bootdata.cc
 	mkdir -p bin
-	vcs -Mlib=work-vcs -Mdir=work-vcs -o bin/snitch_cluster.vcs -cc $(CC) -cpp $(CXX) \
+	vcs -Mlib=$(VCS_BUILDDIR) -Mdir=$(VCS_BUILDDIR) -o bin/snitch_cluster.vcs -cc $(CC) -cpp $(CXX) \
 		-assert disable_cover -override_timescale=1ns/1ps -full64 tb_bin ${TB_DIR}/rtl_lib.cc ${TB_DIR}/common_lib.cc $(GENERATED_DIR)/bootdata.cc \
 		-CFLAGS "-std=c++14 -I${MKFILE_DIR} -I${MKFILE_DIR}/test -I${FESVR}/include -I${TB_DIR}" -LDFLAGS "-L${FESVR}/lib" -lfesvr
 

--- a/target/snitch_cluster/Makefile
+++ b/target/snitch_cluster/Makefile
@@ -16,7 +16,7 @@ SELECT_RUNTIME ?=      # Select snRuntime implementation: "banshee" or "rtl" (de
 .DEFAULT_GOAL := help
 .PHONY: all clean
 all: sw
-clean: clean-sw clean-vsim clean-vlt clean-vcs clean-logs clean-bender
+clean: clean-sw clean-work clean-vsim clean-vlt clean-vcs clean-logs clean-bender clean-generated
 
 ##########
 # Common #
@@ -192,7 +192,7 @@ $(GENERATED_DIR)/bootdata.cc: ${CFG} ${CLUSTER_GEN_PREREQ} | $(GENERATED_DIR)
 
 # Clean all build directories and temporary files for Questasim simulation
 clean-vlt: clean-work
-	rm -rf $(VLT_BUILDDIR)
+	rm -rf bin/snitch_cluster.vlt $(VLT_BUILDDIR)
 
 $(VLT_AR): ${VLT_SOURCES} ${TB_SRCS}
 	$(call VERILATE,testharness)
@@ -223,7 +223,7 @@ bin/snitch_cluster.vlt: $(VLT_AR) $(VLT_COBJ) ${VLT_BUILDDIR}/lib/libfesvr.a
 
 # Clean all build directories and temporary files for Questasim simulation
 clean-vsim: clean-work
-	rm -rf bin/snitch_cluster.vsim bin/snitch_cluster.vsim.gui work-vsim vsim.wlf
+	rm -rf bin/snitch_cluster.vsim bin/snitch_cluster.vsim.gui $(VSIM_BUILDDIR) vsim.wlf
 
 ${VSIM_BUILDDIR}/compile.vsim.tcl: $(VSIM_SOURCES) ${TB_SRCS} ${TB_CC_SOURCES}
 	vlib $(dir $@)
@@ -274,10 +274,13 @@ clean-work:
 	rm -rf work
 
 clean-bender:
-	rm -rf Bender.lock .bender/
+	rm -rf $(ROOT)/Bender.lock $(ROOT)/.bender/
 
 clean-logs:
-	rm -rf logs/
+	rm -rf $(LOGS_DIR)
+
+clean-generated:
+	rm -rf $(GENERATED_DIR)
 
 # Help command
 Blue=\033[1;34m
@@ -292,16 +295,17 @@ help:
 	@echo -e "${Blue}bin/snitch_cluster.vlt  ${Black}Build compilation script and compile all sources for Verilator simulation."
 	@echo -e "${Blue}bin/snitch_cluster.vsim ${Black}Build compilation script and compile all sources for Questasim simulation."
 	@echo -e ""
-	@echo -e "${Blue}sw             ${Black}Build all software."
+	@echo -e "${Blue}sw               ${Black}Build all software."
 	@echo -e ""
-	@echo -e "${Blue}clean          ${Black}Clean everything except traces in logs directory."
-	@echo -e "${Blue}clean-bender   ${Black}Clean Bender dependencies."
-	@echo -e "${Blue}clean-sw       ${Black}Clean all software."
-	@echo -e "${Blue}clean-logs     ${Black}Delete all traces in logs directory."
-	@echo -e "${Blue}clean-vcs      ${Black}Clean all build directories and temporary files for VCS simulation."
-	@echo -e "${Blue}clean-vlt      ${Black}Clean all build directories and temporary files for Verilator simulation."
-	@echo -e "${Blue}clean-vsim     ${Black}Clean all build directories and temporary files for Questasim simulation."
+	@echo -e "${Blue}clean            ${Black}Clean everything except traces in logs directory."
+	@echo -e "${Blue}clean-bender     ${Black}Clean Bender dependencies."
+	@echo -e "${Blue}clean-sw         ${Black}Clean all software."
+	@echo -e "${Blue}clean-generated  ${Black}Delete all generated files in the generated directory."
+	@echo -e "${Blue}clean-logs       ${Black}Delete all traces in logs directory."
+	@echo -e "${Blue}clean-vcs        ${Black}Clean all build directories and temporary files for VCS simulation."
+	@echo -e "${Blue}clean-vlt        ${Black}Clean all build directories and temporary files for Verilator simulation."
+	@echo -e "${Blue}clean-vsim       ${Black}Clean all build directories and temporary files for Questasim simulation."
 	@echo -e ""
 	@echo -e "Additional useful targets from the included Makefrag:"
-	@echo -e "${Blue}traces         ${Black}Generate the better readable traces in .logs/trace_hart_<hart_id>.txt with spike-dasm."
-	@echo -e "${Blue}annotate       ${Black}Annotate the better readable traces in .logs/trace_hart_<hart_id>.s with the source code related with the retired instructions."
+	@echo -e "${Blue}traces           ${Black}Generate the better readable traces in .logs/trace_hart_<hart_id>.txt with spike-dasm."
+	@echo -e "${Blue}annotate         ${Black}Annotate the better readable traces in .logs/trace_hart_<hart_id>.s with the source code related with the retired instructions."

--- a/target/snitch_cluster/Makefile
+++ b/target/snitch_cluster/Makefile
@@ -36,9 +36,8 @@ REGGEN          ?= $(shell $(BENDER) path register_interface)/vendor/lowrisc_ope
 CLUSTER_GEN     ?= $(ROOT)/util/clustergen.py
 CLUSTER_GEN_SRC ?= $(wildcard $(ROOT)/util/clustergen/*.py)
 
-QUESTA_64BIT = -64
-VSIM      	?= vsim ${QUESTA_64BIT}
-VLOG      	?= vlog ${QUESTA_64BIT}
+VSIM      	?= vsim
+VLOG      	?= vlog
 
 #########################
 # Files and directories #
@@ -66,6 +65,13 @@ CFG         = cfg/lru.hjson
 VSIM_BENDER += -t snitch_cluster
 VLT_BENDER  += -t snitch_cluster
 
+VLT_SOURCES  := $(shell ${BENDER} script flist ${VLT_BENDER} | ${SED_SRCS})
+VSIM_SOURCES := $(shell ${BENDER} script flist ${VSIM_BENDER} | ${SED_SRCS})
+
+QUESTA_64BIT = -64
+VLOG_64BIT   = -64
+
+VSIM_FLAGS += ${QUESTA_64BIT}
 VSIM_FLAGS += -t 1ps
 VSIM_FLAGS += -voptargs=+acc
 VSIM_FLAGS += -do "log -r /*; run -a"
@@ -74,7 +80,7 @@ VLOG_FLAGS += -svinputport=compat
 VLOG_FLAGS += -override_timescale 1ns/1ps
 VLOG_FLAGS += -suppress 2583
 VLOG_FLAGS += -suppress 13314
-VLOG_FLAGS += ${QUESTA_64BIT}
+VLOG_FLAGS += ${VLOG_64BIT}
 
 VLT_FLAGS  += --trace
 


### PR DESCRIPTION
Contains various general fixes:
- simutils.py: Capture missing binary error and print also successful tests
- gitlab-ci: Fix path to run.py for tests
- update `target/snitch_cluster/Makefile` `clean` targets
- bender: Move `VSIM_SOURCES`, `VLT_SOURCES` depending on bender target from `common.mk` to `target/snitch_cluster/Makefile`
- gitlab-ci: Fix VCS target dependency such that the required files inside the `generated` directory are actually generated before the compilation
- sw: add runtime compilation for Banshee to github CI
