### PR TITLE
printf: Fix printf support for new runtime

### DIFF
--- a/target/snitch_cluster/sw/runtime/rtl/src/putchar.c
+++ b/target/snitch_cluster/sw/runtime/rtl/src/putchar.c
@@ -1,0 +1,36 @@
+// Copyright 2020 ETH Zurich and University of Bologna.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+extern uintptr_t volatile tohost, fromhost;
+
+// Rudimentary string buffer for putc calls.
+extern uint32_t _edram;
+#define PUTC_BUFFER_LEN (1024 - sizeof(size_t))
+struct putc_buffer_header {
+    size_t size;
+    uint64_t syscall_mem[8];
+};
+static volatile struct putc_buffer {
+    struct putc_buffer_header hdr;
+    char data[PUTC_BUFFER_LEN];
+} *const putc_buffer = (void *)&_edram;
+
+// Provide an implementation for putchar.
+void _putchar(char character) {
+    volatile struct putc_buffer *buf = &putc_buffer[snrt_hartid()];
+    buf->data[buf->hdr.size++] = character;
+    if (buf->hdr.size == PUTC_BUFFER_LEN || character == '\n') {
+        buf->hdr.syscall_mem[0] = 64;  // sys_write
+        buf->hdr.syscall_mem[1] = 1;   // file descriptor (1 = stdout)
+        buf->hdr.syscall_mem[2] = (uintptr_t)&buf->data;  // buffer
+        buf->hdr.syscall_mem[3] = buf->hdr.size;          // length
+
+        tohost = (uintptr_t)buf->hdr.syscall_mem;
+        while (fromhost == 0)
+            ;
+        fromhost = 0;
+
+        buf->hdr.size = 0;
+    }
+}

--- a/target/snitch_cluster/sw/runtime/rtl/src/snrt.c
+++ b/target/snitch_cluster/sw/runtime/rtl/src/snrt.c
@@ -4,9 +4,6 @@
 
 #include "snrt.h"
 
-// Empty printf implementation
-extern int printf(const char* format, ...);
-
 #include "alloc.c"
 #include "cls.c"
 #include "cluster_interrupts.c"
@@ -15,6 +12,8 @@ extern int printf(const char* format, ...);
 #include "eu.c"
 #include "kmp.c"
 #include "omp.c"
+#include "printf.c"
+#include "putchar.c"
 #include "snitch_cluster_start.c"
 #include "sync.c"
 #include "team.c"

--- a/target/snitch_cluster/sw/runtime/rtl/src/snrt.h
+++ b/target/snitch_cluster/sw/runtime/rtl/src/snrt.h
@@ -19,9 +19,6 @@
 #include "sync_decls.h"
 #include "team_decls.h"
 
-// Empty printf implementation
-inline int printf(const char* format, ...) { return 0; };
-
 // Implementation
 #include "alloc.h"
 #include "cls.h"
@@ -32,6 +29,7 @@ inline int printf(const char* format, ...) { return 0; };
 #include "kmp.h"
 #include "omp.h"
 #include "perf_cnt.h"
+#include "printf.h"
 #include "riscv.h"
 #include "snitch_cluster_global_interrupts.h"
 #include "ssr.h"

--- a/target/snitch_cluster/sw/tests/passing-apps.list
+++ b/target/snitch_cluster/sw/tests/passing-apps.list
@@ -39,3 +39,5 @@ interrupt-local
 fence_i
 # interrupt
 simple
+printf_simple
+printf_fmtint


### PR DESCRIPTION
Add lost RTL runtime `putchar` implementation and add `simple_printf` test.

**Attention**: The test does currently not check the actual printed results after the simulation!!!