### PR TITLE
hw: Improve debug parameterization, fix debug CSR RW

### DIFF
--- a/hw/snitch/src/snitch.sv
+++ b/hw/snitch/src/snitch.sv
@@ -2931,4 +2931,7 @@ module snitch import snitch_pkg::*; import riscv_instr::*; #(
   // Make sure that without virtual memory support, translation is never enabled
   `ASSERT(NoVMSupportNoTranslation, (~VMSupport |-> ~trans_active), clk_i, rst_i)
 
+  // Make sure debug IRQ line is not raised when debug mode is not supported
+  `ASSERT(DebugModeUnsupported, irq_i.debug == 1'b1 |-> DebugSupport == 1, clk_i, rst_i)
+
 endmodule

--- a/hw/snitch/src/snitch.sv
+++ b/hw/snitch/src/snitch.sv
@@ -2239,7 +2239,7 @@ module snitch import snitch_pkg::*; import riscv_instr::*; #(
 
   // CSR logic
   always_comb begin
-    csr_rvalue = 1'b0;
+    csr_rvalue = '0;
     csr_dump = 1'b0;
     illegal_csr = '0;
     priv_lvl_d = priv_lvl_q;
@@ -2320,6 +2320,19 @@ module snitch import snitch_pkg::*; import riscv_instr::*; #(
                               | (1   << 30);
           CSR_MHARTID: begin
             csr_rvalue = hart_id_i;
+          end
+          CSR_DCSR: begin
+            csr_rvalue = dcsr_q;
+            dcsr_d.ebreakm = alu_result[15];
+            dcsr_d.step = alu_result[2];
+          end
+          CSR_DPC: begin
+            csr_rvalue = dpc_q;
+            dpc_d = alu_result;
+          end
+          CSR_DSCRATCH0: begin
+            csr_rvalue = dscratch_q;
+            dscratch_d = alu_result;
           end
           `ifdef SNITCH_ENABLE_PERF
           CSR_MCYCLE: begin
@@ -2471,7 +2484,7 @@ module snitch import snitch_pkg::*; import riscv_instr::*; #(
             end else illegal_csr = 1'b1;
           end
           default: begin
-            csr_rvalue = 1'b0;
+            csr_rvalue = '0;
             csr_dump = 1'b1;
           end
         endcase

--- a/hw/snitch_cluster/src/snitch_cc.sv
+++ b/hw/snitch_cluster/src/snitch_cc.sv
@@ -97,6 +97,8 @@ module snitch_cc #(
   /// Insert Pipeline registers immediately after FPU datapath
   parameter bit          RegisterFPUOut     = 0,
   parameter snitch_pma_pkg::snitch_pma_t SnitchPMACfg = '{default: 0},
+  /// Enable debug support.
+  parameter bit          DebugSupport = 1,
   /// Derived parameter *Do not override*
   parameter int unsigned TCDMPorts = (NumSsrs > 1 ? NumSsrs : 1),
   parameter type addr_t = logic [AddrWidth-1:0],
@@ -222,7 +224,8 @@ module snitch_cc #(
     .XFVEC (XFVEC),
     .XFDOTP (XFDOTP),
     .XFAUX (XFauxMerged),
-    .FLEN (FLEN)
+    .FLEN (FLEN),
+    .DebugSupport (DebugSupport)
   ) i_snitch (
     .clk_i ( clk_d2_i ), // if necessary operate on half the frequency
     .rst_i ( ~rst_ni ),

--- a/hw/snitch_cluster/src/snitch_cluster.sv
+++ b/hw/snitch_cluster/src/snitch_cluster.sv
@@ -181,7 +181,9 @@ module snitch_cluster
   // value here. This only applies to the TCDM. The instruction cache macros will break!
   // In case you are using the `RegisterTCDMCuts` feature this adds an
   // additional cycle latency, which is taken into account here.
-  parameter int unsigned MemoryMacroLatency = 1 + RegisterTCDMCuts
+  parameter int unsigned MemoryMacroLatency = 1 + RegisterTCDMCuts,
+  /// Enable debug support.
+  parameter bit         DebugSupport = 1
 ) (
   /// System clock. If `IsoCrossing` is enabled this port is the _fast_ clock.
   /// The slower, half-frequency clock, is derived internally.
@@ -868,7 +870,8 @@ module snitch_cluster
         .RegisterSequencer (RegisterSequencer),
         .RegisterFPUIn (RegisterFPUIn),
         .RegisterFPUOut (RegisterFPUOut),
-        .TCDMAddrWidth (TCDMAddrWidth)
+        .TCDMAddrWidth (TCDMAddrWidth),
+        .DebugSupport (DebugSupport)
       ) i_snitch_cc (
         .clk_i,
         .clk_d2_i (clk_d2),

--- a/hw/snitch_cluster/src/snitch_cluster_wrapper.sv.tpl
+++ b/hw/snitch_cluster/src/snitch_cluster_wrapper.sv.tpl
@@ -331,7 +331,8 @@ module ${cfg['name']}_wrapper (
     .NarrowMaxMstTrans (${cfg['narrow_trans']}),
     .NarrowMaxSlvTrans (${cfg['narrow_trans']}),
     .sram_cfg_t (${cfg['pkg_name']}::sram_cfg_t),
-    .sram_cfgs_t (${cfg['pkg_name']}::sram_cfgs_t)
+    .sram_cfgs_t (${cfg['pkg_name']}::sram_cfgs_t),
+    .DebugSupport (${int(cfg['enable_debug'])})
   ) i_cluster (
     .clk_i,
     .rst_ni,


### PR DESCRIPTION
This includes the contributions from #7 and further gates debug features inside the Snitch core with parameters, controlled by the existing `debug_enable` configuration key:

* It adds software RW to the `dcsr`, `dpc`, and `dscratch0` registers.
* It disables the instantiation of any debug registers, and thus logic through constant propagation, when `debug_enable` is 0.
