### PR TITLE
spike-dasm: Add Snitch ISA aware riscv-isa-sim as submodule

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,10 @@ jobs:
         working-directory: target/snitch_cluster
         run: |
           ./run.py sw/run.yaml --simulator verilator -j
+      - name: Annotate traces
+        working-directory: target/snitch_cluster
+        run: |
+          make LOGS_DIR=./runs/simple/logs annotate -j
 
   # Tests requiring hardware FDIV unit
   sw-snitch-cluster-fdiv-vlt:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,7 @@ jobs:
       - name: Annotate traces
         working-directory: target/snitch_cluster
         run: |
-          make LOGS_DIR=./runs/simple/logs annotate -j
+          make SIM_DIR=./runs/simple annotate -j
 
   # Tests requiring hardware FDIV unit
   sw-snitch-cluster-fdiv-vlt:

--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,7 @@ Bender.lock
 .vscode/
 __pycache__
 
-// Modelsim Fiels
+# Modelsim Files
 *.wlf
 modelsim.ini
 *stacktrace*
@@ -11,6 +11,10 @@ transcript
 
 gmon.out
 
-// Docs
+# Docs
 /site/
 /docs/generated/
+
+# Installation directories
+/.venv/
+/tools/

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -102,7 +102,7 @@ snitch-cluster-vsim:
     - cd target/snitch_cluster
     - make bin/snitch_cluster.vsim
     - ./run.py sw/run.yaml --simulator vsim -j --run-dir runs/vsim
-    - make LOGS_DIR=./runs/vsim/simple/logs annotate -j
+    - make SIM_DIR=./runs/vsim/simple annotate -j
 
 # Banshee
 snitch-cluster-banshee:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -9,33 +9,12 @@ variables:
   TERM: ansi
   FORCE_COLOR: 1
   # Configure environment
-  PYTHON: /usr/local/anaconda3-2022.05/bin/python3
-  BENDER: bender-0.27.1
-  CC: gcc-9.2.0
-  CXX: g++-9.2.0
-  VCS_SEPP: vcs-2020.12
-  VERILATOR_SEPP: verilator-4.110
-  QUESTA_SEPP: questa-2022.3
-  LLVM_BINROOT: /usr/pack/riscv-1.0-kgf/pulp-llvm-0.12.0/bin
   CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER: /usr/pack/gcc-9.2.0-af/linux-x64/bin/gcc
   LLVM_SYS_120_PREFIX: /usr/pack/llvm-12.0.1-af
   CMAKE: cmake-3.18.1
 
 before_script:
-  - $PYTHON -m venv .venv
-  - source .venv/bin/activate
-  # Unpack packages in a local temporary directory which can be safely cleaned
-  # after installation. Also protects against "No space left on device" errors
-  # occurring when the /tmp folder is filled by other processes.
-  - mkdir tmp
-  - TMPDIR=tmp pip install -r python-requirements.txt
-  - rm -rf tmp
-  - $BENDER vendor init
-  # Install spike-dasm
-  # yamllint disable rule:line-length
-  - wget https://github.com/pulp-platform/riscv-isa-sim/releases/download/snitch-v0.1.0/snitch-spike-dasm-0.1.0-x86_64-linux-gnu-almalinux8.7.tar.gz
-  # yamllint enable rule:line-length
-  - tar xzf snitch-spike-dasm-0.1.0-x86_64-linux-gnu-almalinux8.7.tar.gz
+  source iis-setup.sh
 
 ##############
 # Build docs #

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -31,6 +31,11 @@ before_script:
   - TMPDIR=tmp pip install -r python-requirements.txt
   - rm -rf tmp
   - $BENDER vendor init
+  # Install spike-dasm
+  # yamllint disable rule:line-length
+  - wget https://github.com/pulp-platform/riscv-isa-sim/releases/download/snitch-v0.1.0/snitch-spike-dasm-0.1.0-x86_64-linux-gnu-almalinux8.7.tar.gz
+  # yamllint enable rule:line-length
+  - tar xzf snitch-spike-dasm-0.1.0-x86_64-linux-gnu-almalinux8.7.tar.gz
 
 ##############
 # Build docs #
@@ -118,6 +123,7 @@ snitch-cluster-vsim:
     - cd target/snitch_cluster
     - make bin/snitch_cluster.vsim
     - ./run.py sw/run.yaml --simulator vsim -j --run-dir runs/vsim
+    - make LOGS_DIR=./runs/vsim/simple/logs annotate -j
 
 # Banshee
 snitch-cluster-banshee:

--- a/docs/ug/getting_started.md
+++ b/docs/ug/getting_started.md
@@ -11,7 +11,7 @@ git clone https://github.com/pulp-platform/{{ repo  }}.git --recurse-submodules
 
 If you had already cloned the repository without the `--recurse-submodules` flag, clone its submodules:
 ```shell
-git submodule init --recursive
+git submodule update --init --recursive
 ```
 
 ## Tools and environment
@@ -57,7 +57,7 @@ export LLVM_BINROOT="/usr/pack/riscv-1.0-kgf/pulp-llvm-0.12.0/bin"
 # As a temporary workaround (until correct tool versions are installed system-wide):
 export PATH=/usr/scratch/dachstein/colluca/opt/verible/bin:$PATH
 
-# Install spike for spike-dasm (submodule of the repository)
+# Install spike-dasm
 cd sw/deps/riscv-isa-sim
 autoconf
 mkdir build
@@ -65,8 +65,6 @@ cd build
 ../configure
 make
 export PATH=$(pwd):$PATH
-# or use temporary:
-# export PATH=/home/colluca/snitch/bin:$PATH
 ```
 
 Add these commands to your shell startup file (e.g. `~/.bashrc` if you use bash as the default shell) to ensure that the environment is set up correctly every time you open a new shell.

--- a/docs/ug/getting_started.md
+++ b/docs/ug/getting_started.md
@@ -46,46 +46,12 @@ The following instructions are extracted from the Docker container [README.md](h
 
 ## IIS environment setup
 
-To make sure the right versions of each tool are picked up, set the following environment variables, e.g. in a bash shell:
+To make sure the right versions of each tool are picked up on your IIS machine and install additional tools, run:
 
 ```bash
-export PYTHON="/usr/local/anaconda3-2022.05/bin/python3"
-export BENDER="bender-0.27.1"
-export CC="gcc-9.2.0"
-export CXX="g++-9.2.0"
-export LLVM_BINROOT="/usr/pack/riscv-1.0-kgf/pulp-llvm-0.12.0/bin"
-# As a temporary workaround (until correct tool versions are installed system-wide):
-export PATH=/usr/scratch/dachstein/colluca/opt/verible/bin:$PATH
-
-# Install spike-dasm
-cd sw/deps/riscv-isa-sim
-autoconf
-mkdir build
-cd build
-../configure
-make
-export PATH=$(pwd):$PATH
+source iis-setup.sh
 ```
 
-Add these commands to your shell startup file (e.g. `~/.bashrc` if you use bash as the default shell) to ensure that the environment is set up correctly every time you open a new shell.
+Have a look inside the script. You will want to add some of the steps contained therein to your shell startup file, e.g. exporting environment variables and activating the Python virtual environment. This way, every time you open a new shell, your environment will be ready for developing on Snitch, and you won't have to repeat the installation steps.
 
-Create a Python virtual environment:
-
-```shell
-$PYTHON -m venv ~/.venvs/snitch_cluster
-```
-
-Activate your environment, e.g. in a bash shell:
-
-```bash
-source ~/.venvs/snitch_cluster/bin/activate
-```
-
-You may want to add the last command to your shell startup file to ensure that the virtual environment is activated on every new shell you open.
-
-Install the required packages in the currently active virtual environment:
-
-```shell
-pip install -r python-requirements.txt
-```
 <!--end-section-2-->

--- a/docs/ug/getting_started.md
+++ b/docs/ug/getting_started.md
@@ -55,8 +55,18 @@ export CC="gcc-9.2.0"
 export CXX="g++-9.2.0"
 export LLVM_BINROOT="/usr/pack/riscv-1.0-kgf/pulp-llvm-0.12.0/bin"
 # As a temporary workaround (until correct tool versions are installed system-wide):
-export PATH=/home/colluca/snitch/bin:$PATH
 export PATH=/usr/scratch/dachstein/colluca/opt/verible/bin:$PATH
+
+# Install spike for spike-dasm (submodule of the repository)
+cd sw/deps/riscv-isa-sim
+autoconf
+mkdir build
+cd build
+../configure
+make
+export PATH=$(pwd):$PATH
+# or use temporary:
+# export PATH=/home/colluca/snitch/bin:$PATH
 ```
 
 Add these commands to your shell startup file (e.g. `~/.bashrc` if you use bash as the default shell) to ensure that the environment is set up correctly every time you open a new shell.

--- a/iis-setup.sh
+++ b/iis-setup.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# Copyright 2024 ETH Zurich and University of Bologna.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+# Define environment variables
+export PYTHON=/usr/local/anaconda3-2022.05/bin/python3
+export BENDER=bender-0.27.1
+export CC=gcc-9.2.0
+export CXX=g++-9.2.0
+export VCS_SEPP=vcs-2020.12
+export VERILATOR_SEPP=verilator-4.110
+export QUESTA_SEPP=questa-2022.3
+export LLVM_BINROOT=/usr/pack/riscv-1.0-kgf/pulp-llvm-0.12.0/bin
+
+# Create Python virtual environment with required packages
+$PYTHON -m venv .venv
+source .venv/bin/activate
+# Unpack packages in a local temporary directory which can be safely cleaned
+# after installation. Also protects against "No space left on device" errors
+# occurring when the /tmp folder is filled by other processes.
+mkdir tmp
+TMPDIR=tmp pip install -r python-requirements.txt
+rm -rf tmp
+
+# Bender initialization
+$BENDER vendor init
+
+# Install spike-dasm
+mkdir tools/
+cd tools/
+wget https://github.com/pulp-platform/riscv-isa-sim/releases/download/snitch-v0.1.0/snitch-spike-dasm-0.1.0-x86_64-linux-gnu-almalinux8.7.tar.gz
+tar xzf snitch-spike-dasm-0.1.0-x86_64-linux-gnu-almalinux8.7.tar.gz
+cd -
+echo $PATH
+export PATH=$(pwd)/tools:$PATH

--- a/target/common/common.mk
+++ b/target/common/common.mk
@@ -6,9 +6,10 @@
 DEBUG ?= OFF  # ON to turn on wave logging
 
 # Directories
-LOGS_DIR ?= logs
+SIM_DIR  ?= $(shell pwd)
 TB_DIR   ?= $(SNITCH_ROOT)/target/common/test
 UTIL_DIR ?= $(SNITCH_ROOT)/util
+LOGS_DIR  = $(SIM_DIR)/logs
 
 # SEPP packages
 QUESTA_SEPP    ?=
@@ -184,16 +185,14 @@ define QUESTASIM
 	@mkdir -p $(dir $@)
 	@echo "#!/bin/bash" > $@
 	@echo 'binary=$$(realpath $$1)' >> $@
-	@echo 'mkdir -p $(LOGS_DIR)' >> $@
-	@echo 'echo $$binary > $(LOGS_DIR)/.rtlbinary' >> $@
+	@echo 'echo $$binary > .rtlbinary' >> $@
 	@echo '${VSIM} +permissive ${VSIM_FLAGS} $$3 -work ${MKFILE_DIR}/${VSIM_BUILDDIR} -c \
 				-ldflags "-Wl,-rpath,${FESVR}/lib -L${FESVR}/lib -lfesvr -lutil" \
 				$(1)_opt +permissive-off ++$$binary ++$$2' >> $@
 	@chmod +x $@
 	@echo "#!/bin/bash" > $@.gui
 	@echo 'binary=$$(realpath $$1)' >> $@.gui
-	@echo 'mkdir -p $(LOGS_DIR)' >> $@.gui
-	@echo 'echo $$binary > $(LOGS_DIR)/.rtlbinary' >> $@.gui
+	@echo 'echo $$binary > .rtlbinary' >> $@.gui
 	@echo '${VSIM} +permissive ${VSIM_FLAGS} -work ${MKFILE_DIR}/${VSIM_BUILDDIR} \
 				-ldflags "-Wl,-rpath,${FESVR}/lib -L${FESVR}/lib -lfesvr -lutil" \
 				$(1)_opt +permissive-off ++$$binary ++$$2' >> $@.gui
@@ -257,7 +256,7 @@ $(LOGS_DIR)/trace_hart_%.txt $(LOGS_DIR)/hart_%_perf.json: $(LOGS_DIR)/trace_har
 
 # Generate source-code interleaved traces for all harts. Reads the binary from
 # the logs/.rtlbinary file that is written at start of simulation in the vsim script
-BINARY ?= $(shell cat $(LOGS_DIR)/.rtlbinary)
+BINARY ?= $(shell cat $(SIM_DIR)/.rtlbinary)
 $(LOGS_DIR)/trace_hart_%.s: $(LOGS_DIR)/trace_hart_%.txt ${ANNOTATE_PY}
 	$(PYTHON) ${ANNOTATE_PY} ${ANNOTATE_FLAGS} -o $@ $(BINARY) $<
 $(LOGS_DIR)/trace_hart_%.diff: $(LOGS_DIR)/trace_hart_%.txt ${ANNOTATE_PY}

--- a/target/snitch_cluster/Makefile
+++ b/target/snitch_cluster/Makefile
@@ -224,9 +224,17 @@ $(VLT_BUILDDIR)/generated/%.o: $(GENERATED_DIR)/%.cc ${VLT_BUILDDIR}/lib/libfesv
 
 # Build compilation script and compile all sources for Verilator simulation
 # Link verilated archive with $(VLT_COBJ)
-bin/snitch_cluster.vlt: $(VLT_AR) $(VLT_COBJ) ${VLT_BUILDDIR}/lib/libfesvr.a
+bin/.snitch_cluster.vlt.elf: $(VLT_AR) $(VLT_COBJ) ${VLT_BUILDDIR}/lib/libfesvr.a
 	mkdir -p $(dir $@)
 	$(CXX) $(LDFLAGS) -std=c++14 -L ${VLT_BUILDDIR}/lib -o $@ $(VLT_COBJ) $(VLT_AR) -lfesvr -lpthread
+
+# Build wrapper around Verilator binary, needed to create .rtlbinary 
+bin/snitch_cluster.vlt: bin/.snitch_cluster.vlt.elf
+	@echo "#!/bin/bash" > $@
+	@echo 'binary=$$(realpath $$1)' >> $@
+	@echo 'echo $$binary > .rtlbinary' >> $@
+	@echo '$(abspath $<) $$binary $$2' >> $@
+	@chmod +x $@
 
 ############
 # Modelsim #

--- a/util/container/Dockerfile
+++ b/util/container/Dockerfile
@@ -9,6 +9,7 @@ FROM ubuntu:18.04 AS builder
 ARG CMAKE_VERSION=3.19.4
 ARG PYTHON_VERSION=3.9.12
 ARG BENDER_VERSION=0.27.1
+ARG SPIKE_DASM_VERSION=0.1.0
 # Run dpkg without interactive dialogue
 ARG DEBIAN_FRONTEND=noninteractive
 
@@ -76,6 +77,9 @@ RUN cargo install --path /tmp/banshee
 RUN wget https://github.com/pulp-platform/bender/releases/download/v${BENDER_VERSION}/bender-${BENDER_VERSION}-x86_64-linux-gnu-ubuntu18.04.tar.gz
 RUN tar xzf bender-${BENDER_VERSION}-x86_64-linux-gnu-ubuntu18.04.tar.gz
 
+# Install spike-dasm
+RUN wget https://github.com/pulp-platform/riscv-isa-sim/releases/download/snitch-v${SPIKE_DASM_VERSION}/snitch-spike-dasm-${SPIKE_DASM_VERSION}-x86_64-linux-gnu-ubuntu18.04.tar.gz
+RUN tar xzf snitch-spike-dasm-${SPIKE_DASM_VERSION}-x86_64-linux-gnu-ubuntu18.04.tar.gz
 
 # 2. Stage
 FROM ubuntu:18.04 AS snitch_cluster
@@ -141,6 +145,7 @@ RUN apt-get update && apt-get install software-properties-common -y && \
 
 # Copy artifacts from stage 1.
 COPY --from=builder /tools/bender bin/
+COPY --from=builder /tools/spike-dasm bin/
 COPY --from=builder /root/.cargo/bin/banshee bin/
 COPY --from=builder /opt/python /opt/python
 

--- a/util/sim/Simulation.py
+++ b/util/sim/Simulation.py
@@ -92,7 +92,7 @@ class Simulation(object):
         if self.dry_run:
             return 0
         else:
-            if self.process:
+            if self.completed():
                 return int(self.process.returncode)
 
     def successful(self):


### PR DESCRIPTION
Add Snitch ISA aware `riscv-isa-sim` version as submodule. Only used for `spike-dasm` to make the generated traces more readable.

In the old `snitch` repository it was flattened (without `vendor`) from the [repository](https://github.com/huettern/riscv-isa-sim) of @huettern. The branch was ported to the [pulp-platform repository](https://github.com/pulp-platform/riscv-isa-sim/tree/GiannaP-snitch).
