### PR TITLE
ci: Fix flake8 version

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -108,6 +108,7 @@ jobs:
       - name: flake8 Lint
         uses: py-actions/flake8@v2
         with:
+          flake8-version: "6.0.0"
           max-line-length: "100"
 
   ######################


### PR DESCRIPTION
As our linting action takes the "latest" flake8 version by default, CI runs may produce different outcomes if flake8 is updated in the meantime. This may lead to discrepancies between the outcome of the CI on a PR, and the CI on main after merging the PR.

This PR addresses this issue by fixing the flake8 version used by our linting action to the last version which yielded a passing CI status. 