### PR TITLE
CSR dump

### DIFF
--- a/hw/snitch/src/snitch.sv
+++ b/hw/snitch/src/snitch.sv
@@ -2562,7 +2562,8 @@ module snitch import snitch_pkg::*; import riscv_instr::*; #(
     // Display CSR write if the CSR does not exist
     if (!rst_i && csr_dump && inst_valid_o && inst_ready_i && !stall) begin
       // $timeformat(-9, 0, " ns", 0);
-      $display("[DUMP] %t Core %3d: 0x%3h = 0x%08h, %d, %f", $time, hart_id_i, inst_data_i[31:20], alu_result, alu_result, $bitstoshortreal(alu_result));
+      $display("[DUMP] %t Core %3d: 0x%3h = 0x%08h, %d, %f",
+        $time, hart_id_i, inst_data_i[31:20], alu_result, alu_result, $bitstoshortreal(alu_result));
     end
   end
   // pragma translate_on

--- a/hw/snitch/src/snitch.sv
+++ b/hw/snitch/src/snitch.sv
@@ -2562,8 +2562,7 @@ module snitch import snitch_pkg::*; import riscv_instr::*; #(
     // Display CSR write if the CSR does not exist
     if (!rst_i && csr_dump && inst_valid_o && inst_ready_i && !stall) begin
       // $timeformat(-9, 0, " ns", 0);
-      $display("[DUMP] %t Core %3d: 0x%3h = 0x%08h, %d, %f",
-                $time, hart_id_i, inst_data_i[31:20], alu_result, alu_result, $bitstoshortreal(alu_result));
+      $display("[DUMP] %t Core %3d: 0x%3h = 0x%08h, %d, %f", $time, hart_id_i, inst_data_i[31:20], alu_result, alu_result, $bitstoshortreal(alu_result));
     end
   end
   // pragma translate_on

--- a/hw/snitch/src/snitch.sv
+++ b/hw/snitch/src/snitch.sv
@@ -232,6 +232,7 @@ module snitch import snitch_pkg::*; import riscv_instr::*; #(
   // -----
   logic [31:0] csr_rvalue;
   logic csr_en;
+  logic csr_dump;
 
   localparam logic M = 0;
   localparam logic S = 1;
@@ -2239,6 +2240,7 @@ module snitch import snitch_pkg::*; import riscv_instr::*; #(
   // CSR logic
   always_comb begin
     csr_rvalue = '0;
+    csr_dump = '0;
     illegal_csr = '0;
     priv_lvl_d = priv_lvl_q;
     // registers
@@ -2468,7 +2470,10 @@ module snitch import snitch_pkg::*; import riscv_instr::*; #(
               if (!exception) fcsr_d = fcsr_t'(alu_result[9:0]);
             end else illegal_csr = 1'b1;
           end
-          default: csr_rvalue = '0;
+          default: begin
+            csr_rvalue = '0;
+            csr_dump = '1;
+          end
         endcase
       end else illegal_csr = 1'b1;
     end
@@ -2551,6 +2556,17 @@ module snitch import snitch_pkg::*; import riscv_instr::*; #(
     dcsr_d.nmip = 0;
     dcsr_d.prv = dm::priv_lvl_t'(dm::PRIV_LVL_M);
   end
+
+  // pragma translate_off
+  always_ff @(posedge clk_i or posedge rst_i) begin
+    // Display CSR write if the CSR does not exist
+    if (!rst_i && csr_dump && inst_valid_o && inst_ready_i && !stall) begin
+      // $timeformat(-9, 0, " ns", 0);
+      $display("[DUMP] %t Core %3d: 0x%3h = 0x%08h, %d, %f",
+                $time, hart_id_i, inst_data_i[31:20], alu_result, alu_result, $bitstoshortreal(alu_result));
+    end
+  end
+  // pragma translate_on
 
   snitch_regfile #(
     .DATA_WIDTH     ( 32       ),

--- a/sw/snRuntime/src/dump.h
+++ b/sw/snRuntime/src/dump.h
@@ -1,23 +1,28 @@
+// Copyright 2020 ETH Zurich and University of Bologna.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Authors: Samuel Riedel, ETH Zurich <sriedel@iis.ee.ethz.ch>
+//          Viviane Potocnik, ETH Zurich <vivianep@iis.ee.ethz.ch>
+
 // Dump a value via CSR
-// !!! Careful: This is only supported in simulation and an experimental feature. 
-// All writes to unimplemented CSR registers will be dumped by Snitch. This can be
-// exploited to quickly print measurement values from all cores simultaneously
-// without the hassle of printf. To specify multiple metrics, different CSRs can
-// be used.
-// The macro will define a function that will then always print via the same
-// CSR. E.g., `dump(errors, 8)` will define a function with the following
-// signature: `dump_errors(uint32_t val)`, which will print the given value via
-// the 8th register.
-// Alternatively, the `write_csr(reg, val)` macro can be used directly.
+// !!! Careful: This is only supported in simulation and an experimental
+// feature. All writes to unimplemented CSR registers will be dumped by Snitch.
+// This can be exploited to quickly print measurement values from all cores
+// simultaneously without the hassle of printf. To specify multiple metrics,
+// different CSRs can be used. The macro will define a function that will then
+// always print via the same CSR. E.g., `dump(errors, 8)` will define a function
+// with the following signature: `dump_errors(uint32_t val)`, which will print
+// the given value via the 8th register. Alternatively, the `write_csr(reg,
+// val)` macro can be used directly.
 
 #define dump_float(name, reg)                                                  \
-  static                                                                       \
-      __attribute__((always_inline)) inline void dump_##name(float val) {      \
-    asm volatile("csrw " #reg ", %0" ::"rK"(val));                             \
-  }
+    static __attribute__((always_inline)) inline void dump_##name(float val) { \
+        asm volatile("csrw " #reg ", %0" ::"rK"(val));                         \
+    }
 
-#define dump_uint(name, reg)                                                    \
-  static                                                                        \
-      __attribute__((always_inline)) inline void dump_##name(uint32_t val) {    \
-    asm volatile("csrw " #reg ", %0" ::"rK"(val));                              \
-  }
+#define dump_uint(name, reg)                                                   \
+    static                                                                     \
+        __attribute__((always_inline)) inline void dump_##name(uint32_t val) { \
+        asm volatile("csrw " #reg ", %0" ::"rK"(val));                         \
+    }

--- a/sw/snRuntime/src/dump.h
+++ b/sw/snRuntime/src/dump.h
@@ -1,0 +1,23 @@
+// Dump a value via CSR
+// !!! Careful: This is only supported in simulation and an experimental feature. 
+// All writes to unimplemented CSR registers will be dumped by Snitch. This can be
+// exploited to quickly print measurement values from all cores simultaneously
+// without the hassle of printf. To specify multiple metrics, different CSRs can
+// be used.
+// The macro will define a function that will then always print via the same
+// CSR. E.g., `dump(errors, 8)` will define a function with the following
+// signature: `dump_errors(uint32_t val)`, which will print the given value via
+// the 8th register.
+// Alternatively, the `write_csr(reg, val)` macro can be used directly.
+
+#define dump_float(name, reg)                                                  \
+  static                                                                       \
+      __attribute__((always_inline)) inline void dump_##name(float val) {      \
+    asm volatile("csrw " #reg ", %0" ::"rK"(val));                             \
+  }
+
+#define dump_uint(name, reg)                                                    \
+  static                                                                        \
+      __attribute__((always_inline)) inline void dump_##name(uint32_t val) {    \
+    asm volatile("csrw " #reg ", %0" ::"rK"(val));                              \
+  }

--- a/target/snitch_cluster/sw/runtime/rtl/src/snrt.h
+++ b/target/snitch_cluster/sw/runtime/rtl/src/snrt.h
@@ -25,6 +25,7 @@
 #include "cluster_interrupts.h"
 #include "dm.h"
 #include "dma.h"
+#include "dump.h"
 #include "eu.h"
 #include "kmp.h"
 #include "omp.h"


### PR DESCRIPTION
This utility was inspired by MemPool to enable single cycle printf in RTL simulation.
This will **not** work on the actual hardware, but aids debugging. 

You have the option to interpret the register values as either 32-bit float values or 32-bit unsigned integers. Depending on what kind of data you want to display, use the `dump_float` or `dump_uint` utility, respectively. 

As an example, define `dump_float(<name>, <csr_reg_ID>` at the beginning of the file you want to debug. Afterward, you can dump the values to the output of the RTL simulation by calling `dump_<name>(<value>)`. 

You have to be careful when selecting the `csr_reg_ID` as it must **not** be an invalid register ID.  