### PR TITLE
sw: Make compatible with non-12 LLVM versions

### DIFF
--- a/sw/blas/gemm/src/gemm.h
+++ b/sw/blas/gemm/src/gemm.h
@@ -121,7 +121,7 @@ void gemm_fp64_opt(uint32_t M, uint32_t N, uint32_t K, double* A, uint32_t ldA,
     for (uint32_t m = 0; m < M; m++) {
         uint32_t n = 0;
         for (uint32_t n0 = 0; n0 < N / unroll; n0++) {
-            register double c[unroll];
+            double c[unroll];
 
             // Load intermediate result
             if (*ALPHA) {
@@ -234,7 +234,7 @@ void gemm_fp32_opt(const uint32_t M, const uint32_t N, const uint32_t K,
         for (uint32_t n0 = 0; n0 < N / unroll; n0++) {
             float* _C = &C[m * ldC + n / 2];
             const register float zero = 0.0;
-            register v2f32 c[unroll], reduce_reg[unroll];
+            v2f32 c[unroll], reduce_reg[unroll];
 
             asm volatile(
                 "lw      t0, 0(%[ALPHA]) \n"
@@ -384,8 +384,8 @@ void gemm_fp16_opt(uint32_t M, uint32_t N, uint32_t K, __fp16* A, uint32_t ldA,
         for (uint32_t n0 = 0; n0 < N / unroll; n0++) {
             __fp16* _C = &C[m * ldC + n];
             const register float zero = 0.0;
-            register v4f16 c[unroll];
-            register v2f32 reduce_reg[unroll];
+            v4f16 c[unroll];
+            v2f32 reduce_reg[unroll];
             uint32_t alpha;
 
             asm volatile(
@@ -568,8 +568,8 @@ void gemm_fp16_ex_opt(uint32_t M, uint32_t N, uint32_t K, __fp16* A,
         for (uint32_t n0 = 0; n0 < N / unroll; n0++) {
             __fp16* _C = &C[m * ldC + n];
             const register float zero = 0.0;
-            register v4f16 c[unroll];
-            register v2f32 reduce_reg[unroll];
+            v4f16 c[unroll];
+            v2f32 reduce_reg[unroll];
             uint32_t alpha;
 
             asm volatile(
@@ -735,8 +735,8 @@ void gemm_fp8_ex_opt(uint32_t M, uint32_t N, uint32_t K, char* A, uint32_t ldA,
         for (uint32_t n0 = 0; n0 < N / unroll; n0++) {
             char* _C = &C[m * ldC + n];
             const register float zero = 0.0;
-            register v8f8 c[unroll];
-            register v4f16 reduce_reg[unroll];
+            v8f8 c[unroll];
+            v4f16 reduce_reg[unroll];
             uint32_t alpha;
 
             asm volatile(

--- a/target/snitch_cluster/sw/toolchain.mk
+++ b/target/snitch_cluster/sw/toolchain.mk
@@ -17,6 +17,7 @@ DEBUG ?= OFF # ON to turn on debugging symbols
 
 # Compiler toolchain
 LLVM_BINROOT    ?= $(dir $(shell which riscv32-unknown-elf-clang))
+LLVM_VER        ?= $(subst git,,$(shell $(LLVM_BINROOT)/llvm-config --version))
 RISCV_CC        ?= $(LLVM_BINROOT)/clang
 RISCV_LD        ?= $(LLVM_BINROOT)/ld.lld
 RISCV_AR        ?= $(LLVM_BINROOT)/llvm-ar
@@ -48,7 +49,7 @@ RISCV_LDFLAGS += -fuse-ld=$(RISCV_LD)
 RISCV_LDFLAGS += -nostartfiles
 RISCV_LDFLAGS += -nostdlib
 RISCV_LDFLAGS += -lc
-RISCV_LDFLAGS += -L$(LLVM_BINROOT)/../lib/clang/12.0.1/lib/
+RISCV_LDFLAGS += -L$(LLVM_BINROOT)/../lib/clang/$(LLVM_VER)/lib/
 RISCV_LDFLAGS += -lclang_rt.builtins-riscv32
 
 # Archiver flags

--- a/target/snitch_cluster/sw/toolchain.mk
+++ b/target/snitch_cluster/sw/toolchain.mk
@@ -17,7 +17,7 @@ DEBUG ?= OFF # ON to turn on debugging symbols
 
 # Compiler toolchain
 LLVM_BINROOT    ?= $(dir $(shell which riscv32-unknown-elf-clang))
-LLVM_VER        ?= $(subst git,,$(shell $(LLVM_BINROOT)/llvm-config --version))
+LLVM_VER        ?= $(shell $(LLVM_BINROOT)/llvm-config --version | grep -Eo '[0-9]+\.[0-9]+\.[0-9]+')
 RISCV_CC        ?= $(LLVM_BINROOT)/clang
 RISCV_LD        ?= $(LLVM_BINROOT)/ld.lld
 RISCV_AR        ?= $(LLVM_BINROOT)/llvm-ar


### PR DESCRIPTION
This targets the work-in-progress occamy branch, *not* `main`.

Make software build system work with LLVM versions other than 12.0.1 by:

* Making LLVM lib paths adaptive to the version used
* Fixing GNU C language violations in `gemm.h`: `register` may not be used with arrays (this was never legal to begin with, but the frontend lets it slide and the backend only fatals if it actually attempts to map registers)