### PR TITLE
target: Update LRU config mechanism

### DIFF
--- a/target/snitch_cluster/Makefile
+++ b/target/snitch_cluster/Makefile
@@ -119,21 +119,31 @@ VLT_COBJ += $(VLT_BUILDDIR)/generated/bootdata.o
 
 CLUSTER_GEN_PREREQ = ${CLUSTER_GEN} ${CLUSTER_GEN_SRC}
 
+# This target is always evaluated and creates a symlink to the least
+# recently used config file. Because it is a symlink, targets to which it is a
+# prerequisite will only be updated if the symlink target is newer than the
+# depending targets, regardless of the symlink timestamp itself. The symlink
+# timestamp can be taken into account by using the `make -L` flag on the
+# command-line, however for simplicity we touch the symlink targets so it can
+# be used without.
 $(CFG): FORCE
 	@# If the LRU config file doesn't exist, we use the default config.
-	@if [ ! -e $@ ] ; then \
-		DEFAULT_CFG="$(DEFAULT_CFG)"; \
-		echo "Using default config file: $$DEFAULT_CFG"; \
-		cp $$DEFAULT_CFG $@; \
+	@if [ ! -e "$@" ] ; then \
+		echo "Using default config file: $(DEFAULT_CFG) $@"; \
+		ln -s --relative $(DEFAULT_CFG) $@; \
+		touch $(DEFAULT_CFG); \
 	fi
-	@# If a config file is provided on the command-line and it differs
-	@# from the LRU config file then we override the LRU file with it
+	@# If a config file is provided on the command-line and the LRU
+	@# config file doesn't point to it already, then we make it point to it
 	@if [ $(CFG_OVERRIDE) ] ; then \
 		echo "Overriding config file with: $(CFG_OVERRIDE)"; \
-		if cmp -s $(CFG_OVERRIDE) $@ ; then \
-			echo "Override and LRU config files are equivalent. Nothing to be done."; \
+		target=$$(readlink -f $@); \
+		if [ "$$target" = "$(abspath $(CFG_OVERRIDE))" ] ; then \
+			echo "LRU config file already points to $(CFG_OVERRIDE). Nothing to be done."; \
 		else \
-			cp $(CFG_OVERRIDE) $@; \
+			rm -f $@; \
+			ln -s --relative $(CFG_OVERRIDE) $@; \
+			touch $(CFG_OVERRIDE); \
 		fi \
 	fi
 FORCE:


### PR DESCRIPTION
This PR changes the LRU config file mechanism in the following way.

The LRU config file becomes a symlink, pointing to the `cfg/default.hjson` config file by default. Upon an override request (using the `CFG_OVERRIDE` flag) the symlink is updated to point to the requested config file. This is in contrast to the previous implementation, where the LRU config file was a regular file, and the contents of the default or overridden config files were copied into it.

This change allows the following behaviour. If the config file which the LRU config points to changes, any Make target depending on the LRU config will be updated. So you don't have to update the LRU config file contents, but can directly update the original config file (which is now the target of the symlink).