### PR TITLE
target/common: Scale verilator testbench time precision as picoseconds

### DIFF
--- a/target/common/test/verilator_lib.cc
+++ b/target/common/test/verilator_lib.cc
@@ -83,7 +83,7 @@ void Sim::main() {
 }  // namespace sim
 
 // Verilator callback to get the current time.
-double sc_time_stamp() { return sim::TIME * TIME_CYCLES_TO_TIMESTAMP; }
+double sc_time_stamp() { return sim::TIME * sim::TIME_CYCLES_TO_TIMESTAMP; }
 
 // DPI calls.
 void tb_memory_read(long long addr, int len, const svOpenArrayHandle data) {

--- a/target/common/test/verilator_lib.cc
+++ b/target/common/test/verilator_lib.cc
@@ -14,6 +14,11 @@ namespace sim {
 
 // Number of cycles between HTIF checks.
 const int HTIFTimeInterval = 200;
+
+// We want to return timestamp in picosecond accuracy, assuming that one cycle
+// takes 1ns Since 1 cycle takes 2 sim::TIME increments, scale by 500 to get
+// time = cycle * 1000 + <some constant>
+const int TIME_CYCLES_TO_TIMESTAMP = 500;
 void sim_thread_main(void *arg) { ((Sim *)arg)->main(); }
 
 // Sim time.
@@ -78,11 +83,7 @@ void Sim::main() {
 }  // namespace sim
 
 // Verilator callback to get the current time.
-double sc_time_stamp() { 
-    // We want to return timestamp in picosecond accuracy, assuming that one cycle takes 1ns
-    // Since 1 cycle takes 2 time increments, scale by 500 to get time = cycle * 1000 + <some constant>
-    return sim::TIME * 500; 
-}
+double sc_time_stamp() { return sim::TIME * TIME_CYCLES_TO_TIMESTAMP; }
 
 // DPI calls.
 void tb_memory_read(long long addr, int len, const svOpenArrayHandle data) {

--- a/target/common/test/verilator_lib.cc
+++ b/target/common/test/verilator_lib.cc
@@ -17,7 +17,7 @@ const int HTIFTimeInterval = 200;
 void sim_thread_main(void *arg) { ((Sim *)arg)->main(); }
 
 // Sim time.
-int TIME = 0;
+vluint64_t TIME = 0;
 
 Sim::Sim(int argc, char **argv) : htif_t(argc, argv), ipc(argc, argv) {
     // Search arguments for `--vcd` flag and enable waves if requested
@@ -78,7 +78,11 @@ void Sim::main() {
 }  // namespace sim
 
 // Verilator callback to get the current time.
-double sc_time_stamp() { return sim::TIME; }
+double sc_time_stamp() { 
+    // We want to return timestamp in picosecond accuracy, assuming that one cycle takes 1ns
+    // Since 1 cycle takes 2 time increments, scale by 500 to get time = cycle * 1000 + <some constant>
+    return sim::TIME * 500; 
+}
 
 // DPI calls.
 void tb_memory_read(long long addr, int len, const svOpenArrayHandle data) {

--- a/target/common/test/verilator_lib.cc
+++ b/target/common/test/verilator_lib.cc
@@ -78,7 +78,7 @@ void Sim::main() {
 }  // namespace sim
 
 // Verilator callback to get the current time.
-double sc_time_stamp() { return sim::TIME * 1e-9; }
+double sc_time_stamp() { return sim::TIME; }
 
 // DPI calls.
 void tb_memory_read(long long addr, int len, const svOpenArrayHandle data) {


### PR DESCRIPTION
Fixes #57 

Currently, Verilator relies on the global function `sc_time_stamp` to implement the `$time` function in verilog. `$time` is used by the simulator's trace and the performance tooling in the repo to track performance. However, although the current implementation of the testbench increments the time counter on each cycle, it is still dividing this time counter by `1e9`. With the default assumption of 1 cycle taking 1ns and time precision of 1ps, this would imply that we are representing the `sim::TIME` variable as being in attoseconds (`1e18 attoseconds = 1 second`). This PR instead scales the time variable to return the expected picosecond precision. 

Reference example from Verilator 4.100 where no multiplication by `1e-9` takes place: https://github.com/verilator/verilator/blob/v4.100/examples/make_tracing_c/sim_main.cpp

Expected result: `time = cycle *1000 + 3000`. When generating traces in [gen_trace.py](https://github.com/pulp-platform/snitch_cluster/blob/main/util/trace/gen_trace.py#L501-L506) we assume that the time is in milliseconds, so it gives a good enough approximation. A next step could be to have wall time instead, but ultimately I think this leaves the verilator simulator in a better state than before. 

Example logs generated after the patch attached. 

[trace_hart_00000000.txt](https://github.com/pulp-platform/snitch_cluster/files/13166511/trace_hart_00000000.txt)
[perf.csv](https://github.com/pulp-platform/snitch_cluster/files/13166514/perf.csv)
[hart_00000000_perf.json](https://github.com/pulp-platform/snitch_cluster/files/13166515/hart_00000000_perf.json)
[event.csv](https://github.com/pulp-platform/snitch_cluster/files/13166516/event.csv)
