### PR TITLE
hw: Bump FPU, update FP latencies, fix low-precision FP GEMM

### DIFF
--- a/Bender.yml
+++ b/Bender.yml
@@ -22,7 +22,7 @@ dependencies:
   axi:                { git: https://github.com/pulp-platform/axi,                version:  0.39.0  }
   axi_riscv_atomics:  { git: https://github.com/pulp-platform/axi_riscv_atomics,  version:  0.6.0   }
   common_cells:       { git: https://github.com/pulp-platform/common_cells,       version:  1.28.0  }
-  FPnew:              { git: https://github.com/openhwgroup/cvfpu,                rev:      1202ca3 }  # TODO: feature branch `feature/expanding_sdotp`; get merged!
+  FPnew:              { git: "https://github.com/pulp-platform/cvfpu.git",        rev:      pulp-v0.1.3 }
   register_interface: { git: https://github.com/pulp-platform/register_interface, version:  0.4.2   }
   tech_cells_generic: { git: https://github.com/pulp-platform/tech_cells_generic, version:  0.2.11  }
   riscv-dbg:          { git: https://github.com/pulp-platform/riscv-dbg,          version:  0.8.0   }

--- a/hw/snitch_cluster/src/snitch_cc.sv
+++ b/hw/snitch_cluster/src/snitch_cc.sv
@@ -487,6 +487,7 @@ module snitch_cc #(
       .trace_port_o            ( fpu_trace           ),
       .sequencer_tracer_port_o ( fpu_sequencer_trace ),
       // pragma translate_on
+      .hart_id_i        ( hart_id_i      ),
       .acc_req_i        ( acc_snitch_req ),
       .acc_req_valid_i  ( acc_qvalid     ),
       .acc_req_ready_o  ( acc_qready     ),

--- a/hw/snitch_cluster/src/snitch_fp_ss.sv
+++ b/hw/snitch_cluster/src/snitch_fp_ss.sv
@@ -42,6 +42,7 @@ module snitch_fp_ss import snitch_pkg::*; #(
   output fpu_trace_port_t  trace_port_o,
   output fpu_sequencer_trace_port_t sequencer_tracer_port_o,
   // pragma translate_on
+  input  logic [31:0]      hart_id_i,
   // Accelerator Interface - Slave
   input  acc_req_t         acc_req_i,
   input  logic             acc_req_valid_i,
@@ -2509,6 +2510,7 @@ module snitch_fp_ss import snitch_pkg::*; #(
   ) i_fpu (
     .clk_i                           ,
     .rst_ni         ( ~rst_i        ),
+    .hart_id_i      ( hart_id_i     ),
     .operands_i     ( op            ),
     .rnd_mode_i     ( fpu_rnd_mode  ),
     .op_i           ( fpu_op        ),

--- a/hw/snitch_cluster/src/snitch_fpu.sv
+++ b/hw/snitch_cluster/src/snitch_fpu.sv
@@ -19,6 +19,7 @@ module snitch_fpu import snitch_pkg::*; #(
   input logic                               clk_i,
   input logic                               rst_ni,
   // Input signals
+  input logic [31:0]                        hart_id_i,
   input logic [2:0][FLEN-1:0]               operands_i,
   input fpnew_pkg::roundmode_e              rnd_mode_i,
   input fpnew_pkg::operation_e              op_i,
@@ -99,12 +100,15 @@ module snitch_fpu import snitch_pkg::*; #(
 
   fpnew_top #(
     // FPU configuration
-    .Features       ( FPUFeatures ),
-    .Implementation ( FPUImplementation ),
-    .TagType        ( logic[6:0]        )
+    .Features                    ( FPUFeatures            ),
+    .Implementation              ( FPUImplementation      ),
+    .TagType                     ( logic[6:0]             ),
+    .CompressedVecCmpResult      ( 1                      ),
+    .StochasticRndImplementation ( fpnew_pkg::DEFAULT_RSR )
   ) i_fpu (
     .clk_i                                    ,
     .rst_ni                                   ,
+    .hart_id_i       ( hart_id_i             ),
     .operands_i      ( fpu_in_q.operands     ),
     .rnd_mode_i      ( fpu_in_q.rnd_mode     ),
     .op_i            ( fpu_in_q.op           ),
@@ -114,6 +118,7 @@ module snitch_fpu import snitch_pkg::*; #(
     .int_fmt_i       ( fpu_in_q.int_fmt      ),
     .vectorial_op_i  ( fpu_in_q.vectorial_op ),
     .tag_i           ( fpu_in_q.tag          ),
+    .simd_mask_i     ( '1                    ),
     .in_valid_i      ( in_valid_q            ),
     .in_ready_o      ( in_ready_q            ),
     .flush_i         ( 1'b0                  ),

--- a/sw/blas/gemm/src/gemm.h
+++ b/sw/blas/gemm/src/gemm.h
@@ -929,9 +929,9 @@ void gemm(precision_t prec, uint32_t expand, uint32_t setup_ssr,
             }
             break;
         case FP8:
-            gemm_fp8_ex_opt(frac_m, n, k, (char*)a + offsetA, lda, (char*)b,
-                            ldb, (char*)c + offsetC, ldc_strided, &beta,
-                            setup_ssr);
+            gemm_fp8_ex_opt(frac_m, n, k, (char*)a + offsetA, lda_strided,
+                            (char*)b, ldb, (char*)c + offsetC, ldc_strided,
+                            &beta, setup_ssr);
             break;
     }
 }

--- a/sw/blas/gemm/src/main.c
+++ b/sw/blas/gemm/src/main.c
@@ -56,8 +56,6 @@ int main() {
         // Transpose of A unsopported
         if (TA) return -1;
         if (TB) {
-            // Transpose of B supported only in FP64
-            if (dtype_size != FP64) return -1;
             ldb = K;
         }
 

--- a/sw/blas/gemm/src/main.c
+++ b/sw/blas/gemm/src/main.c
@@ -89,18 +89,18 @@ int main() {
                 switch (dtype_size) {
                     case FP64:
                         if (fabs(result[idx] - ((double *)local_c)[idx]) <
-                            0.001)
+                            fabs(result[idx] * 0.00001))
                             errors--;
                         break;
                     case FP32:
-                        if (fabs(result[idx] - ((float *)local_c)[idx]) < 0.001)
+                        if (fabs(result[idx] - ((float *)local_c)[idx]) <
+                            fabs(result[idx] * 0.0001))
                             errors--;
                         break;
                     case FP16:
                         if (fabs(result[idx] - ((__fp16 *)local_c)[idx]) <
-                            0.065)
+                            fabs(result[idx] * 0.005))
                             errors--;
-                        break;
                     case FP8:
                         printf("No golden model yet for fp8!\n");
                         return -1;

--- a/sw/blas/gemm/src/main.c
+++ b/sw/blas/gemm/src/main.c
@@ -98,7 +98,7 @@ int main() {
                         break;
                     case FP16:
                         if (fabs(result[idx] - ((__fp16 *)local_c)[idx]) <
-                            0.001)
+                            0.065)
                             errors--;
                         break;
                     case FP8:

--- a/sw/blas/gemm/src/main.c
+++ b/sw/blas/gemm/src/main.c
@@ -75,6 +75,8 @@ int main() {
         snrt_dma_wait_all();
     }
 
+    snrt_cluster_hw_barrier();
+
 // TODO: currently only works for single cluster otherwise need to
 //       synchronize all cores here
 #ifdef BIST
@@ -86,16 +88,16 @@ int main() {
                 uint32_t idx = m * N + n;
                 switch (dtype_size) {
                     case FP64:
-                        if (fabs(result[idx] - ((double *)local_c)[idx]) >
+                        if (fabs(result[idx] - ((double *)local_c)[idx]) <
                             0.001)
                             errors--;
                         break;
                     case FP32:
-                        if (fabs(result[idx] - ((float *)local_c)[idx]) > 0.001)
+                        if (fabs(result[idx] - ((float *)local_c)[idx]) < 0.001)
                             errors--;
                         break;
                     case FP16:
-                        if (fabs(result[idx] - ((__fp16 *)local_c)[idx]) >
+                        if (fabs(result[idx] - ((__fp16 *)local_c)[idx]) <
                             0.001)
                             errors--;
                         break;

--- a/sw/blas/gemm/src/main.c
+++ b/sw/blas/gemm/src/main.c
@@ -50,13 +50,15 @@ int main() {
         uint32_t start_cycle = snrt_mcycle();
 
         volatile uint32_t lda = K;
-        volatile uint32_t ldb = N;
+        volatile uint32_t ldb = K;
         volatile uint32_t ldc = N;
 
         // Transpose of A unsopported
         if (TA) return -1;
-        if (TB) {
-            ldb = K;
+        if (!TB) {
+            // Transpose of B supported only in FP64
+            if (dtype_size != FP64) return -1;
+            ldb = N;
         }
 
         gemm(dtype_size, expand, setup_ssr, TA, TB, frac_m, N, K, 1, local_a,

--- a/target/snitch_cluster/cfg/default.hjson
+++ b/target/snitch_cluster/cfg/default.hjson
@@ -34,8 +34,8 @@
             lat_comp_fp8: 1,
             lat_comp_fp8_alt: 1,
             lat_noncomp: 1,
-            lat_conv: 1,
-            lat_sdotp: 2,
+            lat_conv: 2,
+            lat_sdotp: 3,
             fpu_pipe_config: "BEFORE"
             narrow_xbar_latency: "CUT_ALL_PORTS",
             wide_xbar_latency: "CUT_ALL_PORTS",

--- a/target/snitch_cluster/sw/apps/common.mk
+++ b/target/snitch_cluster/sw/apps/common.mk
@@ -82,7 +82,7 @@ $(ELF): $(SRCS) $(DEP) $(LIBS) | $(BUILDDIR)
 	$(RISCV_CC) $(RISCV_CFLAGS) $(RISCV_LDFLAGS) $(SRCS) -o $@
 
 $(DUMP): $(ELF) | $(BUILDDIR)
-	$(RISCV_OBJDUMP) -D --mcpu=snitch $< > $@
+	$(RISCV_OBJDUMP) $(RISCV_OBJDUMP_FLAGS) $< > $@
 
 $(DWARF): $(ELF) | $(BUILDDIR)
 	$(RISCV_DWARFDUMP) $< > $@

--- a/target/snitch_cluster/sw/apps/common.mk
+++ b/target/snitch_cluster/sw/apps/common.mk
@@ -82,7 +82,7 @@ $(ELF): $(SRCS) $(DEP) $(LIBS) | $(BUILDDIR)
 	$(RISCV_CC) $(RISCV_CFLAGS) $(RISCV_LDFLAGS) $(SRCS) -o $@
 
 $(DUMP): $(ELF) | $(BUILDDIR)
-	$(RISCV_OBJDUMP) -D $< > $@
+	$(RISCV_OBJDUMP) -D --mcpu=snitch $< > $@
 
 $(DWARF): $(ELF) | $(BUILDDIR)
 	$(RISCV_DWARFDUMP) $< > $@

--- a/target/snitch_cluster/sw/toolchain.mk
+++ b/target/snitch_cluster/sw/toolchain.mk
@@ -55,3 +55,7 @@ RISCV_LDFLAGS += -lclang_rt.builtins-riscv32
 
 # Archiver flags
 RISCV_ARFLAGS = rcs
+
+# Objdump flags
+RISCV_OBJDUMP_FLAGS += --mcpu=snitch
+RISCV_OBJDUMP_FLAGS += -D


### PR DESCRIPTION
This PR removes an IF statement preventing from running low precision FP GEMM. 
The FP latencies in the snitch cluster default configuration are aligned with the Occamy configuration.
The FPU is bumped to the latest version `pulp-v0.1.3`.  The hart_id is propagated to the FPUs. The hart_id is used to initialize the seed of the LFSR used for stochastic rounding in each of the wDotp modules.
The SW check on the GEMM results has been modified to consider relative errors.