### PR TITLE
(Not a PR to main): Improve DMA tracer handling of 1d requests after 2d requests and scale units correctly

### DIFF
--- a/util/trace/gen_trace.py
+++ b/util/trace/gen_trace.py
@@ -410,6 +410,7 @@ def update_dma(insn, extras, dma_trans):
             # Create new placeholder transaction
             dma_trans.append(dma_trans[-1].copy())
             dma_trans[-1].pop('size')
+            dma_trans[-1]['rep'] = 1
 
 
 def eval_dma_metrics(dma_trans, dma_trace):

--- a/util/trace/gen_trace.py
+++ b/util/trace/gen_trace.py
@@ -457,7 +457,7 @@ def eval_dma_metrics(dma_trans, dma_trace):
                         compl_transfers.append(compl_transfer)
         # Calculate bandwidth of individual transfers
         for transfer in compl_transfers:
-            transfer['cycles'] = transfer['end'] - transfer['start']
+            transfer['cycles'] = (transfer['end'] - transfer['start']) // 1000
             transfer['bw'] = transfer['bytes'] / transfer['cycles']
         # Calculate aggregate bandwidth: total number of bytes transferred while any
         # transfer is active (considers overlaps between transfers).
@@ -466,7 +466,8 @@ def eval_dma_metrics(dma_trans, dma_trace):
         n_bytes = 0
         for transfer in compl_transfers:
             # Calculate active cycles, without double-counting overlaps
-            curr_trans_start, curr_trans_end = transfer['start'], transfer['end']
+            # Convert time to cycles since time = cycles * 1000 + <constant>
+            curr_trans_start, curr_trans_end = transfer['start'] // 1000, transfer['end'] // 1000
             if curr_trans_start > prev_trans_end:
                 active_cycles += curr_trans_end - curr_trans_start
             else:


### PR DESCRIPTION
This PR achieves two things:
- When a 1D DMA request is issued after a 2d request, the repetition count of the 2d request is still retained in the placeholder transaction. This causes the # bytes transferred tracking in `eval_dma_metrics` to omit generating a new DMA transfer placeholder after the 1D dma request is completed, leading to an IndexError  on `outst_transfers` when `exp_bursts` is accessed afterwards. 
- Bandwidth is stated to be calculated as bytes/cycle. However, the `start`/`end` metric currently reported in the DMA verilog `hw/future/src/dma/axi_dma_backend.sv` is measured in picoseconds (1000 * cycles + <constant>) as mentioned in https://github.com/pulp-platform/snitch_cluster/pull/58:
https://github.com/pulp-platform/snitch_cluster/blob/82233b608c239e49fdc7efaf9c0681aec8dd31d1/hw/future/src/dma/axi_dma_backend.sv#L338
as such, scale time down by 1000 to convert it into cycles unit. 