### PR TITLE
Switch to Verilator 5 and update other dependencies

### DIFF
--- a/target/common/common.mk
+++ b/target/common/common.mk
@@ -31,9 +31,6 @@ PERF_CSV_PY      ?= $(UTIL_DIR)/trace/perf_csv.py
 LAYOUT_EVENTS_PY ?= $(UTIL_DIR)/trace/layout_events.py
 EVENTVIS_PY      ?= $(UTIL_DIR)/trace/eventvis.py
 
-VERILATOR_ROOT ?= $(dir $(shell $(VERILATOR_SEPP) which verilator))..
-VLT_ROOT       ?= ${VERILATOR_ROOT}
-
 MATCH_END := '/+incdir+/ s/$$/\/*\/*/'
 MATCH_BGN := 's/+incdir+//g'
 SED_SRCS  := sed -e ${MATCH_END} -e ${MATCH_BGN}
@@ -51,12 +48,13 @@ VCS_BUILDDIR := work-vcs
 
 # fesvr is being installed here
 FESVR         ?= ${MKFILE_DIR}work
-FESVR_VERSION ?= 35d50bc40e59ea1d5566fbd3d9226023821b1bb6
+FESVR_VERSION ?= b98de6f689b426dce3f3d013408b4017b1018c08
 
 VLT_BENDER   += -t rtl
 VLT_SOURCES   = $(shell ${BENDER} script flist ${VLT_BENDER} | ${SED_SRCS})
 VLT_BUILDDIR := work-vlt
 VLT_FESVR     = $(VLT_BUILDDIR)/riscv-isa-sim
+VLT_FLAGS    += --no-timing
 VLT_FLAGS    += -Wno-BLKANDNBLK
 VLT_FLAGS    += -Wno-LITENDIAN
 VLT_FLAGS    += -Wno-CASEINCOMPLETE
@@ -67,8 +65,8 @@ VLT_FLAGS    += -Wno-UNSIGNED
 VLT_FLAGS    += -Wno-UNOPTFLAT
 VLT_FLAGS    += -Wno-fatal
 VLT_FLAGS    += --unroll-count 1024
-VLT_CFLAGS   += -std=c++14 -pthread
-VLT_CFLAGS   +=-I ${VLT_BUILDDIR} -I $(VLT_ROOT)/include -I $(VLT_ROOT)/include/vltstd -I $(VLT_FESVR)/include -I $(TB_DIR) -I ${MKFILE_DIR}/test
+VLT_CFLAGS   += -std=c++20 -pthread
+VLT_CFLAGS   += -I $(VLT_ROOT)/include -I $(VLT_ROOT)/include/vltstd -I ../$(VLT_FESVR)/include -I $(TB_DIR) -I ${MKFILE_DIR}test
 
 ANNOTATE_FLAGS ?= -q --keep-time
 

--- a/target/snitch_cluster/Makefile
+++ b/target/snitch_cluster/Makefile
@@ -100,20 +100,6 @@ RTL_CC_SOURCES += ${TB_DIR}/rtl_lib.cc
 VLT_CC_SOURCES += \
 	${TB_DIR}/verilator_lib.cc \
 	${TB_DIR}/tb_bin.cc
-				
-
-# Required C sources for the verilator TB that are linked against the verilated model
-VLT_COBJ += $(VLT_BUILDDIR)/tb/bootrom.o
-VLT_COBJ += $(VLT_BUILDDIR)/tb/ipc.o
-VLT_COBJ += $(VLT_BUILDDIR)/tb/common_lib.o
-VLT_COBJ += $(VLT_BUILDDIR)/tb/verilator_lib.o
-VLT_COBJ += $(VLT_BUILDDIR)/tb/tb_bin.o
-# Sources from verilator root
-VLT_COBJ += $(VLT_BUILDDIR)/vlt/verilated.o
-VLT_COBJ += $(VLT_BUILDDIR)/vlt/verilated_dpi.o
-VLT_COBJ += $(VLT_BUILDDIR)/vlt/verilated_vcd_c.o
-# Bootdata
-VLT_COBJ += $(VLT_BUILDDIR)/generated/bootdata.o
 
 #################
 # Prerequisites #

--- a/target/snitch_cluster/Makefile
+++ b/target/snitch_cluster/Makefile
@@ -86,15 +86,21 @@ VLT_FLAGS  += --trace
 TB_CC_SOURCES += \
 	${TB_DIR}/bootrom.cc \
 	${TB_DIR}/ipc.cc \
-	${TB_DIR}/rtl_lib.cc \
 	${TB_DIR}/common_lib.cc \
 	$(GENERATED_DIR)/bootdata.cc
 
 TB_CC_FLAGS += \
-	-std=c++14 \
+	-std=c++20 \
 	-I${MKFILE_DIR}/test \
 	-I${FESVR}/include \
 	-I${TB_DIR}
+
+RTL_CC_SOURCES += ${TB_DIR}/rtl_lib.cc
+
+VLT_CC_SOURCES += \
+	${TB_DIR}/verilator_lib.cc \
+	${TB_DIR}/tb_bin.cc
+				
 
 # Required C sources for the verilator TB that are linked against the verilated model
 VLT_COBJ += $(VLT_BUILDDIR)/tb/bootrom.o
@@ -209,26 +215,14 @@ $(GENERATED_DIR)/bootdata.cc: ${CFG} ${CLUSTER_GEN_PREREQ} | $(GENERATED_DIR)
 clean-vlt: clean-work
 	rm -rf bin/snitch_cluster.vlt $(VLT_BUILDDIR)
 
-$(VLT_AR): ${VLT_SOURCES} ${TB_SRCS}
-	$(call VERILATE,testharness)
-verilate: $(VLT_AR)
-
-# Build targets for verilator TB
-$(VLT_BUILDDIR)/tb/%.o: $(TB_DIR)/%.cc $(VLT_AR) ${VLT_BUILDDIR}/lib/libfesvr.a
-	mkdir -p $(dir $@)
-	$(CXX) $(CXXFLAGS) $(VLT_CFLAGS) -c $< -o $@
-$(VLT_BUILDDIR)/vlt/%.o: $(VLT_ROOT)/include/%.cpp
-	mkdir -p $(dir $@)
-	$(CXX) $(CXXFLAGS) $(VLT_CFLAGS) -c $< -o $@
-$(VLT_BUILDDIR)/generated/%.o: $(GENERATED_DIR)/%.cc ${VLT_BUILDDIR}/lib/libfesvr.a
-	mkdir -p $(dir $@)
-	$(CXX) $(CXXFLAGS) $(VLT_CFLAGS) -c $< -o $@
-
-# Build compilation script and compile all sources for Verilator simulation
-# Link verilated archive with $(VLT_COBJ)
-bin/snitch_cluster.vlt: $(VLT_AR) $(VLT_COBJ) ${VLT_BUILDDIR}/lib/libfesvr.a
-	mkdir -p $(dir $@)
-	$(CXX) $(LDFLAGS) -std=c++14 -L ${VLT_BUILDDIR}/lib -o $@ $(VLT_COBJ) $(VLT_AR) -lfesvr -lpthread
+bin/snitch_cluster.vlt: ${VLT_SOURCES} ${TB_CC_SOURCES} ${VLT_CC_SOURCES} ${VLT_BUILDDIR}/lib/libfesvr.a
+	mkdir -p $(dir $@) 
+	$(VLT) $(shell $(BENDER) script verilator $(VLT_BENDER)) \
+		$(VLT_FLAGS) -Mdir $(VLT_BUILDDIR) \
+		-CFLAGS "$(VLT_CFLAGS)" \
+		-LDFLAGS "-Llib -lfesvr -lpthread" \
+		-o ../$@ --cc --exe --top-module testharness $(TB_CC_SOURCES) $(VLT_CC_SOURCES)
+	$(MAKE) -C $(VLT_BUILDDIR) -j $(shell nproc) -f Vtestharness.mk
 
 ############
 # Modelsim #
@@ -243,11 +237,11 @@ clean-vsim: clean-work
 ${VSIM_BUILDDIR}/compile.vsim.tcl:
 	$(VLIB) $(dir $@)
 	${BENDER} script vsim ${VSIM_BENDER} --vlog-arg="${VLOG_FLAGS} -work $(dir $@) " > $@
-	echo '${VLOG} -work $(dir $@) ${TB_CC_SOURCES} ${TB_ASM_SOURCES} -vv -ccflags "$(TB_CC_FLAGS)"' >> $@
+	echo '${VLOG} -work $(dir $@) ${TB_CC_SOURCES} ${RTL_CC_SOURCES} ${TB_ASM_SOURCES} -vv -ccflags "$(TB_CC_FLAGS)"' >> $@
 	echo 'return 0' >> $@
 
 # Build compilation script and compile all sources for Questasim simulation
-bin/snitch_cluster.vsim: ${VSIM_BUILDDIR}/compile.vsim.tcl $(VSIM_SOURCES) ${TB_SRCS} ${TB_CC_SOURCES} ${TB_ASM_SOURCES} work/lib/libfesvr.a
+bin/snitch_cluster.vsim: ${VSIM_BUILDDIR}/compile.vsim.tcl $(VSIM_SOURCES) ${TB_SRCS} ${TB_CC_SOURCES} ${RTL_CC_SOURCES} ${TB_ASM_SOURCES} work/lib/libfesvr.a
 	$(call QUESTASIM,tb_bin)
 
 #######
@@ -261,10 +255,10 @@ clean-vcs: clean-work
 	rm -rf bin/snitch_cluster.vcs $(VCS_BUILDDIR) vc_hdrs.h
 
 # Build compilation script and compile all sources for VCS simulation
-bin/snitch_cluster.vcs: ${VCS_SOURCES} ${TB_SRCS} $(TB_CC_SOURCES) $(TB_ASM_SOURCES) $(VCS_BUILDDIR)/compile.sh work/lib/libfesvr.a
+bin/snitch_cluster.vcs: ${VCS_SOURCES} ${TB_SRCS} $(TB_CC_SOURCES) $(RTL_CC_SOURCES) $(TB_ASM_SOURCES) $(VCS_BUILDDIR)/compile.sh work/lib/libfesvr.a
 	mkdir -p bin
 	$(VCS) -Mlib=$(VCS_BUILDDIR) -Mdir=$(VCS_BUILDDIR) -o bin/snitch_cluster.vcs -cc $(CC) -cpp $(CXX) \
-		-assert disable_cover -override_timescale=1ns/1ps -full64 tb_bin $(TB_CC_SOURCES) $(TB_ASM_SOURCES) \
+		-assert disable_cover -override_timescale=1ns/1ps -full64 tb_bin $(TB_CC_SOURCES) $(RTL_CC_SOURCES) $(TB_ASM_SOURCES) \
 		-CFLAGS "$(TB_CC_FLAGS)" -LDFLAGS "-L${FESVR}/lib" -lfesvr
 
 ########

--- a/util/container/Dockerfile
+++ b/util/container/Dockerfile
@@ -5,8 +5,9 @@
 # Docker container for Snitch development.
 
 # 1. Stage
-FROM ubuntu:18.04 AS builder
+FROM ubuntu:22.04 AS builder
 ARG CMAKE_VERSION=3.19.4
+ARG VERILATOR_VERSION=5.006
 
 COPY apt-requirements.txt /tmp/apt-requirements.txt
 RUN apt-get update && \
@@ -21,7 +22,13 @@ RUN apt-get update && \
         software-properties-common \
         unzip \
         wget \
-        zlib1g-dev
+        zlib1g-dev \
+        autoconf \
+        help2man \
+        flex \
+        bison \
+        llvm-12-dev \
+        libclang-common-12-dev
 
 # Build Rust tools
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
@@ -32,10 +39,14 @@ RUN rustup override set 1.70.0
 # Install Bender
 RUN cargo install bender --version 0.27.1
 
-# Get LLVM 12
-RUN wget https://apt.llvm.org/llvm.sh
-RUN chmod +x llvm.sh
-RUN ./llvm.sh 12
+# Build Verilator
+RUN git clone https://github.com/verilator/verilator && \
+    cd verilator && \
+    git checkout "v${VERILATOR_VERSION}" && \
+    autoconf && \
+    ./configure --prefix /tools/verilator && \
+    make && \
+    make install
 
 WORKDIR /tools
 
@@ -52,10 +63,9 @@ RUN git clone https://github.com/pulp-platform/banshee.git /tmp/banshee --recurs
 RUN cargo install --path /tmp/banshee
 
 # 2. Stage
-FROM ubuntu:18.04 AS snitch_cluster
+FROM ubuntu:22.04 AS snitch_cluster
 ARG SNITCH_LLVM_VERSION=latest
-ARG VERIBLE_VERSION=0.0-776-g09e0b87
-ARG VERILATOR_VERSION=4.100
+ARG VERIBLE_VERSION=0.0-3318-g8d254167
 
 LABEL version="0.1"
 LABEL description="Snitch container for hardware and software development."
@@ -80,14 +90,6 @@ RUN apt-get update && \
     apt-get clean ; \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* /usr/share/doc/*
 
-# Install Verilator
-RUN echo 'deb http://download.opensuse.org/repositories/home:/phiwag:/edatools/xUbuntu_18.04/ /' | tee /etc/apt/sources.list.d/home:phiwag:edatools.list && \
-    curl -fsSL https://download.opensuse.org/repositories/home:phiwag:edatools/xUbuntu_18.04/Release.key | gpg --dearmor | tee /etc/apt/trusted.gpg.d/home_phiwag_edatools.gpg > /dev/null && \
-    apt-get update && apt-get install -y verilator-${VERILATOR_VERSION} && \
-    apt-get clean ; \
-    rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* /usr/share/doc/*
-ENV VLT_ROOT "/usr/share/verilator"
-
 # Install Python requirements
 COPY python-requirements.txt /tmp/python-requirements.txt
 COPY docs/requirements.txt /tmp/docs/requirements.txt
@@ -98,7 +100,7 @@ RUN pip3 install -r /tmp/python-requirements.txt
 RUN latest_tag=`curl -s -H "Accept: application/vnd.github.v3+json" https://api.github.com/repos/pulp-platform/llvm-project/releases/latest | grep '"tag_name":' | sed -E 's/.*"([^"]+)".*/\1/'` && \
     echo "SNITCH_LLVM_VERSION=${SNITCH_LLVM_VERSION} LLVM_TAR=${LLVM_TAR} latest_tag=${latest_tag}" && \
     test "${SNITCH_LLVM_VERSION}" = "latest" && SNITCH_LLVM_VERSION=${latest_tag} || : ; \
-    LLVM_TAR=riscv32-pulp-llvm-ubuntu1804-$(echo $SNITCH_LLVM_VERSION | cut -d '-' -f3-).tar.gz && \
+    LLVM_TAR=riscv32-pulp-llvm-ubuntu2004-$(echo $SNITCH_LLVM_VERSION | cut -d '-' -f3-).tar.gz && \
     mkdir -p riscv-llvm && \
     echo "SNITCH_LLVM_VERSION=${SNITCH_LLVM_VERSION} LLVM_TAR=${LLVM_TAR} latest_tag=${latest_tag}" && \
     wget -qO- https://github.com/pulp-platform/llvm-project/releases/download/${SNITCH_LLVM_VERSION}/${LLVM_TAR} | \
@@ -106,9 +108,9 @@ RUN latest_tag=`curl -s -H "Accept: application/vnd.github.v3+json" https://api.
 ENV LLVM_BINROOT "/tools/riscv-llvm/bin"
 
 # Install Verible
-RUN wget https://github.com/google/verible/releases/download/v${VERIBLE_VERSION}/verible-v${VERIBLE_VERSION}-Ubuntu-18.04-bionic-x86_64.tar.gz && \
-    tar -x -f verible-v${VERIBLE_VERSION}-Ubuntu-18.04-bionic-x86_64.tar.gz --strip-components=1 -C . && \
-    rm -rf verible-v${VERIBLE_VERSION}-Ubuntu-18.04-bionic-x86_64.tar.gz
+RUN wget https://github.com/chipsalliance/verible/releases/download/v${VERIBLE_VERSION}/verible-v${VERIBLE_VERSION}-linux-static-x86_64.tar.gz && \
+    tar -x -f verible-v${VERIBLE_VERSION}-linux-static-x86_64.tar.gz --strip-components=1 -C . && \
+    rm -rf verible-v${VERIBLE_VERSION}-linux-static-x86_64.tar.gz
 ENV PATH "/tools/bin:${PATH}"
 
 # Install git>=2.18, required by Github checkout action to recurse submodules
@@ -120,6 +122,8 @@ RUN apt-get update && apt-get install software-properties-common -y && \
 # Copy artifacts from stage 1.
 COPY --from=builder /root/.cargo/bin/bender bin/
 COPY --from=builder /root/.cargo/bin/banshee bin/
+COPY --from=builder /tools/verilator /tools/verilator/
+ENV PATH "/tools/verilator/bin:${PATH}"
 
 # Set locale to UTF-8, required because Python 3.6 defaults on ASCII encoding.
 # See https://click.palletsprojects.com/en/8.1.x/unicode-support/


### PR DESCRIPTION
Fixes #6 and #75.

I changed the way the Makefile works to compile both the sv and c++ files with verilator. Moreover, I did the following:
- Added a `no-timing` flag to the verilator command
- Changed the c++ std from c++14 to c++20 (recommended by verilator)
- Changed the spike fesvr version to a more recent one to support GCC13 (see [this PR](https://github.com/riscv-software-src/riscv-isa-sim/pull/1284)). Unfortunately, this newer version requires at least c++17, which is not compatible with verilator 4. Therefore, verilator 4 does not work with this PR!
- Updated the dockerfile. It now uses ubuntu 22.04. It builds verilator 5.006 from the source and now uses the same verible version as the CI.

To test it, I did the following:
- [x] Run verilator tests using docker
- [x] Run banshee tests using docker

I do not have access to modelsim, so I couldn't test that.

If you have any comments/questions, please let me know!