### PR TITLE
Extend simulation utilities

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,9 +17,7 @@ clean: clean-docs
 doc-srcs: $(GENERATED_DOC_SRCS)
 
 docs: doc-srcs
-	@if mkdocs build | grep -q "ERROR"; then \
-		exit 1; \
-	fi
+	mkdocs build
 
 clean-docs:
 	rm -rf $(GENERATED_DOCS_DIR)

--- a/apt-requirements.txt
+++ b/apt-requirements.txt
@@ -6,8 +6,4 @@
 clang-format
 device-tree-compiler
 graphviz
-python3
-python3-pip
-python3-setuptools
-python3-wheel
 tar

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -4,7 +4,8 @@
 
 # Keep sorted.
 mkdocs
-# Last version compatible with python-3.6 (default on Ubuntu 18.04)
-mkdocs-material <= 8.2.11
+mkdocs-material
 mkdocs-include-markdown-plugin
 mkdocs-macros-plugin
+mkdocstrings
+mkdocstrings-python

--- a/docs/rm/sim/Simulation.md
+++ b/docs/rm/sim/Simulation.md
@@ -1,0 +1,1 @@
+::: Simulation

--- a/docs/rm/sim/Simulator.md
+++ b/docs/rm/sim/Simulator.md
@@ -1,0 +1,1 @@
+::: Simulator

--- a/docs/rm/sim/sim_utils.md
+++ b/docs/rm/sim/sim_utils.md
@@ -1,0 +1,1 @@
+::: sim_utils

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -22,6 +22,10 @@ markdown_extensions:
       emoji_generator: !!python/name:materialx.emoji.to_svg
 plugins:
   - include-markdown
+  - mkdocstrings:
+      handlers:
+        python:
+          paths: [util/sim]
   - macros:
       on_error_fail: true
 use_directory_urls: false
@@ -49,10 +53,15 @@ nav:
           - Custom Instructions: rm/custom_instructions.md
           # - Solder: rm/solder.md
       - Software:
-          - Pages: runtime/Pages/index.md
-          - Files: runtime/Files/index.md
-          - Classes: runtime/Classes/index.md
-          - Examples: runtime/Examples/index.md
-          - Modules: runtime/Modules/index.md
-          - Namespaces: runtime/Namespaces/index.md
+          - Simulation Utilities:
+              - sim_utils: rm/sim/sim_utils.md
+              - rm/sim/Simulation.md
+              - rm/sim/Simulator.md
+          - Snitch Runtime:
+              - Pages: runtime/Pages/index.md
+              - Files: runtime/Files/index.md
+              - Classes: runtime/Classes/index.md
+              - Examples: runtime/Examples/index.md
+              - Modules: runtime/Modules/index.md
+              - Namespaces: runtime/Namespaces/index.md
   - Publications: publications.md

--- a/target/common/common.mk
+++ b/target/common/common.mk
@@ -2,6 +2,10 @@
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
+# Makefile invocation
+DEBUG ?= OFF  # ON to turn on wave logging
+
+# Directories
 LOGS_DIR ?= logs
 TB_DIR   ?= $(SNITCH_ROOT)/target/common/test
 UTIL_DIR ?= $(SNITCH_ROOT)/util
@@ -41,7 +45,13 @@ SED_SRCS  := sed -e ${MATCH_END} -e ${MATCH_BGN}
 VSIM_BENDER   += -t test -t rtl -t simulation -t vsim
 VSIM_SOURCES   = $(shell ${BENDER} script flist ${VSIM_BENDER} | ${SED_SRCS})
 VSIM_BUILDDIR ?= work-vsim
+VSIM_FLAGS    += -t 1ps
+ifeq ($(DEBUG), ON)
+VSIM_FLAGS    += -do "log -r /*; run -a"
 VOPT_FLAGS     = +acc
+else
+VSIM_FLAGS    += -do "run -a"
+endif
 
 # VCS_BUILDDIR should to be the same as the `DEFAULT : ./work-vcs`
 # in target/snitch_cluster/synopsys_sim.setup

--- a/target/snitch_cluster/Makefile
+++ b/target/snitch_cluster/Makefile
@@ -9,7 +9,7 @@
 # Makefile invocation #
 #######################
 
-DEBUG          ?= OFF  # ON to turn on debugging symbols
+DEBUG          ?= OFF  # ON to turn on debugging symbols and wave logging
 CFG_OVERRIDE   ?=      # Override default config file
 SELECT_RUNTIME ?=      # Select snRuntime implementation: "banshee" or "rtl" (default)
 
@@ -68,8 +68,6 @@ QUESTA_64BIT = -64
 VLOG_64BIT   = -64
 
 VSIM_FLAGS += ${QUESTA_64BIT}
-VSIM_FLAGS += -t 1ps
-VSIM_FLAGS += -do "log -r /*; run -a"
 
 VLOG_FLAGS += -svinputport=compat
 VLOG_FLAGS += -override_timescale 1ns/1ps

--- a/target/snitch_cluster/run.py
+++ b/target/snitch_cluster/run.py
@@ -24,12 +24,12 @@ SIMULATORS = {
 
 def main():
     args = parser('vsim', SIMULATORS.keys()).parse_args()
-    simulations = get_simulations(args.testlist, SIMULATORS[args.simulator])
+    simulations = get_simulations(args.testlist, SIMULATORS[args.simulator], args.run_dir)
     return run_simulations(simulations,
                            n_procs=args.n_procs,
-                           run_dir=Path(args.run_dir),
                            dry_run=args.dry_run,
-                           early_exit=args.early_exit)
+                           early_exit=args.early_exit,
+                           verbose=args.verbose)
 
 
 if __name__ == '__main__':

--- a/target/snitch_cluster/sw/run.yaml
+++ b/target/snitch_cluster/sw/run.yaml
@@ -68,7 +68,7 @@ runs:
   - elf: tests/build/varargs_2.elf
   - elf: tests/build/zero_mem.elf
   - elf: tests/build/non_null_exitcode.elf
-    exit_code: 14
+    retcode: 14
   - elf: apps/blas/axpy/build/axpy.elf
     cmd: [../../../sw/blas/axpy/verify.py, "${sim_bin}", "${elf}"]
   - elf: apps/blas/gemm/build/gemm.elf

--- a/util/container/Dockerfile
+++ b/util/container/Dockerfile
@@ -7,7 +7,11 @@
 # 1. Stage
 FROM ubuntu:18.04 AS builder
 ARG CMAKE_VERSION=3.19.4
+ARG PYTHON_VERSION=3.9.12
+# Run dpkg without interactive dialogue
+ARG DEBIAN_FRONTEND=noninteractive
 
+# Install APT requirements
 COPY apt-requirements.txt /tmp/apt-requirements.txt
 RUN apt-get update && \
     sed 's/#.*//' /tmp/apt-requirements.txt \
@@ -20,8 +24,26 @@ RUN apt-get update && \
         lsb-release \
         software-properties-common \
         unzip \
-        wget \
-        zlib1g-dev
+        wget
+# Required to install Python
+RUN apt-get update && apt-get install -y \
+        zlib1g-dev \
+        libreadline-gplv2-dev \
+        libncursesw5-dev \
+        libssl-dev \
+        libsqlite3-dev \
+        tk-dev \
+        libgdbm-dev \
+        libc6-dev \
+        libbz2-dev \
+        libffi-dev
+
+# Install Python
+RUN wget https://www.python.org/ftp/python/${PYTHON_VERSION}/Python-${PYTHON_VERSION}.tgz
+RUN tar xzf Python-${PYTHON_VERSION}.tgz
+RUN cd Python-${PYTHON_VERSION} && \
+    ./configure --enable-optimizations --prefix=/opt/python/ && \
+    make install -j
 
 # Build Rust tools
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
@@ -37,6 +59,7 @@ RUN wget https://apt.llvm.org/llvm.sh
 RUN chmod +x llvm.sh
 RUN ./llvm.sh 12
 
+# Change working directory
 WORKDIR /tools
 
 # Install a newer version of cmake (we need this for banshee)
@@ -88,12 +111,6 @@ RUN echo 'deb http://download.opensuse.org/repositories/home:/phiwag:/edatools/x
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* /usr/share/doc/*
 ENV VLT_ROOT "/usr/share/verilator"
 
-# Install Python requirements
-COPY python-requirements.txt /tmp/python-requirements.txt
-COPY docs/requirements.txt /tmp/docs/requirements.txt
-COPY sw/dnn/requirements.txt /tmp/sw/dnn/requirements.txt
-RUN pip3 install -r /tmp/python-requirements.txt
-
 # Get the precompiled LLVM toolchain
 RUN latest_tag=`curl -s -H "Accept: application/vnd.github.v3+json" https://api.github.com/repos/pulp-platform/llvm-project/releases/latest | grep '"tag_name":' | sed -E 's/.*"([^"]+)".*/\1/'` && \
     echo "SNITCH_LLVM_VERSION=${SNITCH_LLVM_VERSION} LLVM_TAR=${LLVM_TAR} latest_tag=${latest_tag}" && \
@@ -120,6 +137,17 @@ RUN apt-get update && apt-get install software-properties-common -y && \
 # Copy artifacts from stage 1.
 COPY --from=builder /root/.cargo/bin/bender bin/
 COPY --from=builder /root/.cargo/bin/banshee bin/
+COPY --from=builder /opt/python /opt/python
+
+# Create and activate virtual environment
+ENV VIRTUAL_ENV "/root/.venvs/snitch_cluster"
+RUN /opt/python/bin/python3 -m venv ${VIRTUAL_ENV}
+ENV PATH="${VIRTUAL_ENV}/bin:${PATH}"
+# Install Python requirements
+COPY python-requirements.txt /tmp/python-requirements.txt
+COPY docs/requirements.txt /tmp/docs/requirements.txt
+COPY sw/dnn/requirements.txt /tmp/sw/dnn/requirements.txt
+RUN pip install -r /tmp/python-requirements.txt
 
 # Set locale to UTF-8, required because Python 3.6 defaults on ASCII encoding.
 # See https://click.palletsprojects.com/en/8.1.x/unicode-support/

--- a/util/container/Dockerfile
+++ b/util/container/Dockerfile
@@ -100,6 +100,7 @@ RUN apt-get update && \
         gnupg2 \
         curl \
         wget \
+        build-essential \
         git && \
     apt-get clean ; \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* /usr/share/doc/*

--- a/util/container/Dockerfile
+++ b/util/container/Dockerfile
@@ -96,6 +96,7 @@ RUN apt-get update && \
     sed 's/#.*//' /tmp/apt-requirements.txt \
         | xargs apt-get install -y && \
     apt-get install -y --no-install-recommends \
+        ca-certificates \
         gnupg2 \
         curl \
         wget \

--- a/util/sim/Simulation.py
+++ b/util/sim/Simulation.py
@@ -17,7 +17,7 @@ class Simulation(object):
 
     LOG_FILE = 'sim.txt'
 
-    def __init__(self, elf=None):
+    def __init__(self, elf=None, dry_run=False, retcode=0, run_dir=None):
         """Constructor for the Simulation class.
 
         A Simulation object is defined at a minimum by a software
@@ -26,14 +26,22 @@ class Simulation(object):
 
         Arguments:
             elf: The software binary to simulate.
+            run_dir: The directory where to launch the simulation
+                command. If none is passed, the current working
+                directory is assumed.
+            dry_run: A preview of the simulation command will be
+                displayed without actually launching the simulation.
         """
         self.elf = elf
+        self.dry_run = dry_run
+        self.run_dir = run_dir if run_dir is not None else Path.cwd()
         self.testname = Path(self.elf).stem
         self.cmd = []
         self.log = None
         self.process = None
+        self.expected_retcode = int(retcode)
 
-    def launch(self, run_dir=None, dry_run=False):
+    def launch(self, dry_run=None):
         """Launch the simulation.
 
         Launch the simulation by invoking the command stored in the
@@ -41,40 +49,52 @@ class Simulation(object):
         a non-empty `cmd` attribute prior to invoking this method.
 
         Arguments:
-            run_dir: The directory where to launch the simulation
-                command.
-            dry_run: Use dry-run mode to preview the simulation command
+            dry_run: A preview of the simulation command is displayed
                 without actually launching the simulation.
         """
-        # Default to current working directory as simulation directory
-        if not run_dir:
-            run_dir = Path.cwd()
+        # Override dry_run setting at launch time
+        if dry_run is not None:
+            self.dry_run = dry_run
 
         # Print launch message and simulation command
         cprint(f'Run test {colored(self.elf, "cyan")}', attrs=["bold"])
         cmd_string = ' '.join(self.cmd)
-        print(f'$ {cmd_string}', flush=True)
+        print(f'[{self.run_dir}]$ {cmd_string}', flush=True)
 
         # Launch simulation if not doing a dry run
-        if not dry_run:
+        if not self.dry_run:
             # Create run directory and log file
-            os.makedirs(run_dir, exist_ok=True)
-            self.log = run_dir / self.LOG_FILE
+            os.makedirs(self.run_dir, exist_ok=True)
+            self.log = self.run_dir / self.LOG_FILE
             # Launch simulation subprocess
             with open(self.log, 'w') as f:
                 self.process = subprocess.Popen(self.cmd, stdout=f, stderr=subprocess.STDOUT,
-                                                cwd=run_dir, universal_newlines=True)
+                                                cwd=self.run_dir, universal_newlines=True)
 
     def completed(self):
         """Return whether the simulation completed."""
-        if self.process:
+        if self.dry_run:
+            return True
+        elif self.process:
             return self.process.poll() is not None
         else:
             return False
 
+    def get_retcode(self):
+        """Get the return code of the simulation."""
+        if self.dry_run:
+            return 0
+        else:
+            if self.process:
+                return int(self.process.returncode)
+
     def successful(self):
         """Return whether the simulation was successful."""
-        return None
+        actual_retcode = self.get_retcode()
+        if actual_retcode is not None:
+            return int(actual_retcode) == int(self.expected_retcode)
+        else:
+            return False
 
     def print_log(self):
         """Print a log of the simulation to stdout."""
@@ -96,42 +116,8 @@ class Simulation(object):
             cprint(f'{self.elf} test running', 'black', flush=True)
 
 
-class BistSimulation(Simulation):
-    """A simulation that verifies itself.
-
-    A built-in self-test (BIST) simulation is one which verifies
-    itself, i.e. the simulated software binary executes some
-    verification logic to verify that the execution was successful.
-    The return code of the simulation is used to indicate if the
-    simulation was successful or not.
-    """
-
-    def __init__(self, retcode=0, **kwargs):
-        """Constructor for the BistSimulation class.
-
-        Arguments:
-            retcode: The expected return code of the simulation.
-            kwargs: Arguments passed to the base class constructor.
-        """
-        super().__init__(**kwargs)
-        self.expected_retcode = retcode
-        self.actual_retcode = None
-
-    def get_retcode(self):
-        return None
-
-    def successful(self):
-        # Simulation is successful if it returned a return code, and
-        # the return code matches the expected value
-        self.actual_retcode = self.get_retcode()
-        if self.actual_retcode is not None:
-            return int(self.actual_retcode) == int(self.expected_retcode)
-        else:
-            return False
-
-
-class RTLSimulation(BistSimulation):
-    """A BIST simulation run on an RTL simulator.
+class RTLSimulation(Simulation):
+    """A simulation run on an RTL simulator.
 
     An RTL simulation is launched through a simulation binary built
     in advance from some RTL design.
@@ -178,7 +164,7 @@ class QuestaVCSSimulation(RTLSimulation):
                     regex_fail = r'\[FAILURE\] Finished with exit code\s+(\d+)'
                     match = re.search(regex_fail, line)
                     if match:
-                        return match.group(1)
+                        return int(match.group(1))
 
     def successful(self):
         # Check that simulation return code matches expected value (in super class)
@@ -203,8 +189,8 @@ class VCSSimulation(QuestaVCSSimulation):
     pass
 
 
-class BansheeSimulation(BistSimulation):
-    """A BIST simulation running on Banshee.
+class BansheeSimulation(Simulation):
+    """A simulation running on Banshee.
 
     The return code of the simulation is returned directly as the
     return code of the command launching the simulation.
@@ -220,9 +206,6 @@ class BansheeSimulation(BistSimulation):
         super().__init__(**kwargs)
         self.cmd = ['banshee', '--no-opt-llvm', '--no-opt-jit', '--configuration',
                     str(banshee_cfg), '--trace', str(self.elf)]
-
-    def get_retcode(self):
-        return self.process.returncode
 
 
 class CustomSimulation(Simulation):
@@ -247,13 +230,13 @@ class CustomSimulation(Simulation):
             kwargs: Arguments passed to the base class constructor.
         """
         super().__init__(**kwargs)
-        self.dynamic_args = {'sim_bin': str(sim_bin), 'elf': str(self.elf)}
+        self.dynamic_args = {
+            'sim_bin': str(sim_bin),
+            'elf': str(self.elf),
+            'run_dir': str(self.run_dir)
+        }
         self.cmd = cmd
 
-    def launch(self, run_dir=None, dry_run=False):
-        self.dynamic_args['run_dir'] = str(run_dir)
+    def launch(self, **kwargs):
         self.cmd = [Template(arg).render(**self.dynamic_args) for arg in self.cmd]
-        super().launch(run_dir, dry_run)
-
-    def successful(self):
-        return self.process.returncode == 0
+        super().launch(**kwargs)

--- a/util/sim/Simulation.py
+++ b/util/sim/Simulation.py
@@ -106,8 +106,14 @@ class BistSimulation(Simulation):
     simulation was successful or not.
     """
 
-    def __init__(self, elf=None, retcode=0):
-        super().__init__(elf)
+    def __init__(self, retcode=0, **kwargs):
+        """Constructor for the BistSimulation class.
+
+        Arguments:
+            retcode: The expected return code of the simulation.
+            kwargs: Arguments passed to the base class constructor.
+        """
+        super().__init__(**kwargs)
         self.expected_retcode = retcode
         self.actual_retcode = None
 
@@ -131,8 +137,14 @@ class RTLSimulation(BistSimulation):
     in advance from some RTL design.
     """
 
-    def __init__(self, elf=None, retcode=0, sim_bin=None):
-        super().__init__(elf, retcode)
+    def __init__(self, sim_bin=None, **kwargs):
+        """Constructor for the RTLSimulation class.
+
+        Arguments:
+            sim_bin: The simulation binary.
+            kwargs: Arguments passed to the base class constructor.
+        """
+        super().__init__(**kwargs)
         self.cmd = [str(sim_bin), str(self.elf)]
 
 
@@ -155,7 +167,6 @@ class QuestaVCSSimulation(RTLSimulation):
     """
 
     def get_retcode(self):
-
         # Extract the application's return code from the simulation log
         with open(self.log, 'r') as f:
             for line in f.readlines():
@@ -182,8 +193,8 @@ class QuestaVCSSimulation(RTLSimulation):
 class QuestaSimulation(QuestaVCSSimulation):
     """An RTL simulation running on QuestaSim."""
 
-    def __init__(self, elf=None, retcode=0, sim_bin=None):
-        super().__init__(elf, retcode, sim_bin)
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
         self.cmd += ['', '-batch']
 
 
@@ -199,8 +210,14 @@ class BansheeSimulation(BistSimulation):
     return code of the command launching the simulation.
     """
 
-    def __init__(self, elf=None, retcode=0, banshee_cfg=None):
-        super().__init__(elf, retcode)
+    def __init__(self, banshee_cfg=None, **kwargs):
+        """Constructor for the BansheeSimulation class.
+
+        Arguments:
+            banshee_cfg: A Banshee config file.
+            kwargs: Arguments passed to the base class constructor.
+        """
+        super().__init__(**kwargs)
         self.cmd = ['banshee', '--no-opt-llvm', '--no-opt-jit', '--configuration',
                     str(banshee_cfg), '--trace', str(self.elf)]
 
@@ -221,9 +238,16 @@ class CustomSimulation(Simulation):
     any additional logic here.
     """
 
-    def __init__(self, elf=None, sim_bin=None, cmd=None):
-        super().__init__(elf)
-        self.dynamic_args = {'sim_bin': str(sim_bin), 'elf': str(elf)}
+    def __init__(self, sim_bin=None, cmd=None, **kwargs):
+        """Constructor for the CustomSimulation class.
+
+        Arguments:
+            sim_bin: The simulation binary.
+            cmd: The custom command used to launch the simulation.
+            kwargs: Arguments passed to the base class constructor.
+        """
+        super().__init__(**kwargs)
+        self.dynamic_args = {'sim_bin': str(sim_bin), 'elf': str(self.elf)}
         self.cmd = cmd
 
     def launch(self, run_dir=None, dry_run=False):

--- a/util/sim/Simulator.py
+++ b/util/sim/Simulator.py
@@ -9,19 +9,66 @@ from Simulation import QuestaSimulation, VCSSimulation, VerilatorSimulation, Ban
 
 
 class Simulator(object):
+    """An object capable of constructing Simulation objects.
+
+    A simulator constructs a [Simulation][Simulation.Simulation] object
+    from a test object, as defined e.g. in a test suite specification
+    file.
+
+    At minimum, a test is defined by a binary (`elf`) which is to be
+    simulated and a set of simulators it can be run on. A test could be
+    defined by a class of its own, but at the moment we assume a test
+    to be represented by a dictionary with the `elf` and `simulators`
+    keys at minimum.
+    """
 
     def __init__(self, name, simulation_cls):
+        """Constructor for the Simulator class.
+
+        A simulator must be identifiable by a unique identifier string
+        and construct at least one type of
+        [Simulation][Simulation.Simulation] object.
+
+        Arguments:
+            name: The unique identifier of the simulator.
+            simulation_cls: One type of
+                [Simulation][Simulation.Simulation] object the
+                simulator can construct.
+        """
         self.name = name
         self.simulation_cls = simulation_cls
 
     def supports(self, test):
+        """Check whether a certain test is supported by the simulator.
+
+        Arguments:
+            test: The test to check.
+        """
         return 'simulators' not in test or self.name in test['simulators']
 
     def get_simulation(self, test):
+        """Construct a Simulation object from the specified test.
+
+        Arguments:
+            test: The test for which a Simulation object must be
+                constructed.
+        """
         return self.simulation_cls(test['elf'])
 
 
 class RTLSimulator(Simulator):
+    """Base class for RTL simulators.
+
+    An RTL simulator requires a simulation binary built from an RTL
+    design to launch a simulation.
+
+    A test may need to be run with a custom command, itself invoking
+    the simulation binary behind the scenes, e.g. for verification
+    purposes. Such a test carries the custom command (a list of args)
+    under the `cmd` key. In such case, the RTL simulator constructs a
+    [CustomSimulation][Simulation.CustomSimulation] object from the
+    given test, with the custom command and simulation binary.
+    """
 
     def __init__(self, name, simulation_cls, binary):
         super().__init__(name, simulation_cls)
@@ -39,30 +86,58 @@ class RTLSimulator(Simulator):
 
 
 class VCSSimulator(RTLSimulator):
+    """VCS simulator
+
+    An [RTL simulator][Simulator.RTLSimulator], identified by the name
+    `vcs`, tailored to the creation of
+    [VCS simulations][Simulation.VCSSimulation].
+    """
 
     def __init__(self, binary):
         super().__init__('vcs', VCSSimulation, binary)
 
 
 class QuestaSimulator(RTLSimulator):
+    """QuestaSim simulator
+
+    An [RTL simulator][Simulator.RTLSimulator], identified by the name
+    `vsim`, tailored to the creation of
+    [QuestaSim simulations][Simulation.QuestaSimulation].
+    """
 
     def __init__(self, binary):
         super().__init__('vsim', QuestaSimulation, binary)
 
 
 class VerilatorSimulator(RTLSimulator):
+    """Verilator simulator
+
+    An [RTL simulator][Simulator.RTLSimulator], identified by the name
+    `verilator`, tailored to the creation of
+    [Verilator simulations][Simulation.VerilatorSimulation].
+    """
 
     def __init__(self, binary):
         super().__init__('verilator', VerilatorSimulation, binary)
 
 
 class BansheeSimulator(Simulator):
+    """Banshee simulator
+
+    A simulator, identified by the name `banshee`, tailored to the
+    creation of [Banshee simulations][Simulation.BansheeSimulation].
+    """
 
     def __init__(self, cfg):
         super().__init__('banshee', BansheeSimulation)
         self.cfg = cfg
 
     def supports(self, test):
+        """See base class.
+
+        The Banshee simulator does not support tests carrying a custom
+        command.
+        """
         supported = super().supports(test)
         if 'cmd' in test:
             return False

--- a/util/sim/Simulator.py
+++ b/util/sim/Simulator.py
@@ -70,16 +70,22 @@ class RTLSimulator(Simulator):
     given test, with the custom command and simulation binary.
     """
 
-    def __init__(self, name, simulation_cls, binary):
-        super().__init__(name, simulation_cls)
+    def __init__(self, binary, **kwargs):
+        """Constructor for the RTLSimulator class.
+
+        Arguments:
+            binary: The simulation binary.
+            kwargs: Arguments passed to the base class constructor.
+        """
+        super().__init__(**kwargs)
         self.binary = binary
 
     def get_simulation(self, test):
         if 'cmd' in test:
-            return CustomSimulation(test['elf'], self.binary, test['cmd'])
+            return CustomSimulation(elf=test['elf'], sim_bin=self.binary, cmd=test['cmd'])
         else:
             return self.simulation_cls(
-                test['elf'],
+                elf=test['elf'],
                 retcode=test['exit_code'] if 'exit_code' in test else 0,
                 sim_bin=self.binary
             )
@@ -94,7 +100,12 @@ class VCSSimulator(RTLSimulator):
     """
 
     def __init__(self, binary):
-        super().__init__('vcs', VCSSimulation, binary)
+        """Constructor for the VCSSimulator class.
+
+        Arguments:
+            binary: The VCS simulation binary.
+        """
+        super().__init__(binary, name='vcs', simulation_cls=VCSSimulation)
 
 
 class QuestaSimulator(RTLSimulator):
@@ -106,7 +117,12 @@ class QuestaSimulator(RTLSimulator):
     """
 
     def __init__(self, binary):
-        super().__init__('vsim', QuestaSimulation, binary)
+        """Constructor for the QuestaSimulator class.
+
+        Arguments:
+            binary: The QuestaSim simulation binary.
+        """
+        super().__init__(binary, name='vsim', simulation_cls=QuestaSimulation)
 
 
 class VerilatorSimulator(RTLSimulator):
@@ -118,7 +134,12 @@ class VerilatorSimulator(RTLSimulator):
     """
 
     def __init__(self, binary):
-        super().__init__('verilator', VerilatorSimulation, binary)
+        """Constructor for the VerilatorSimulator class.
+
+        Arguments:
+            binary: The Verilator simulation binary.
+        """
+        super().__init__(binary, name='verilator', simulation_cls=VerilatorSimulation)
 
 
 class BansheeSimulator(Simulator):
@@ -129,7 +150,12 @@ class BansheeSimulator(Simulator):
     """
 
     def __init__(self, cfg):
-        super().__init__('banshee', BansheeSimulation)
+        """Constructor for the BansheeSimulator class.
+
+        Arguments:
+            cfg: A Banshee config file.
+        """
+        super().__init__(name='banshee', simulation_cls=BansheeSimulation)
         self.cfg = cfg
 
     def supports(self, test):
@@ -146,7 +172,7 @@ class BansheeSimulator(Simulator):
 
     def get_simulation(self, test):
         return self.simulation_cls(
-            test['elf'],
+            elf=test['elf'],
             retcode=test['exit_code'] if 'exit_code' in test else 0,
             banshee_cfg=self.cfg
         )

--- a/util/sim/sim_utils.py
+++ b/util/sim/sim_utils.py
@@ -3,6 +3,49 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 # Luca Colagrande <colluca@iis.ee.ethz.ch>
+"""Convenience functions to set up a Python simulation framework.
+
+Such a framework enables you to transparently run a software test suite
+on any simulator of choice, provided that the latter is supported by
+the framework. It can be used in CIs, regression testing or to conduct
+systematic evaluation experiments.
+
+Three interfaces are required to implement a common framework:
+
+1. a test suite specification interface to specify the software tests
+2. a command-line interface used to launch the simulations
+3. an interface to the simulators supported by the framework
+
+The framework can be divided into three components each managing one of
+the defined interfaces:
+
+1. a test suite frontend
+2. a command-line frontend
+3. a simulation backend
+
+A fourth component, the core, serves to glue all other components
+together.
+
+The [parser()][sim_utils.parser] function provides a minimum
+command-line interface to control the tool.
+
+The [get_simulations()][sim_utils.get_simulations] function
+provides a common means to implement the test suite frontend. At the
+input interface it assumes a test suite specification file in YAML
+syntax, and returns a list of simulation objects which implement a
+common interface to the simulation backend. This interface is defined
+by the [Simulation][Simulation.Simulation] class.
+
+The core logic of the framework is implemented in the
+[run_simulations()][sim_utils.run_simulations] function. It takes
+the output from [get_simulations()][sim_utils.get_simulations] and
+launches the simulations through the interface to the simulation
+backend.
+
+The simulation backend is implemented by the
+[Simulation][Simulation.Simulation] and
+[Simulator][Simulator.Simulator] classes and their subclasses.
+"""
 
 import argparse
 from termcolor import colored, cprint
@@ -17,6 +60,18 @@ POLL_PERIOD = 0.2
 
 
 def parser(default_simulator='vsim', simulator_choices=['vsim']):
+    """Default command-line parser for Python simulation frameworks.
+
+    Returns a Python `argparse` parser with common options used to
+    simulate one or multiple binaries on an RTL design. Can be extended
+    by adding arguments to it.
+
+    Args:
+        default_simulator: The simulator to be used when none is
+            specified on the command-line.
+        simulator_choices: All simulator choices which can be passed on
+            the command-line.
+    """
     # Argument parsing
     parser = argparse.ArgumentParser()
     parser.add_argument(
@@ -57,9 +112,17 @@ def parser(default_simulator='vsim', simulator_choices=['vsim']):
     return parser
 
 
-# Checks if a string s represents a valid relative path w.r.t. to a certain base_path and resolves
-# it to an absolute path, if this is the case. Otherwise returns the original string.
-def resolve_relative_path(base_path, s):
+def _resolve_relative_path(base_path, s):
+    """Resolve a relative path string w.r.t. a ceratin base.
+
+    Checks if an input string represents a valid relative path w.r.t.
+    to a certain base path and resolves it to an absolute path, if this
+    is the case. Otherwise returns the original string.
+
+    Args:
+        s: The input string
+        base_path: The base path
+    """
     try:
         base_path = Path(base_path).resolve()  # Get the absolute path of the base directory
         input_path = Path(s)
@@ -78,8 +141,21 @@ def resolve_relative_path(base_path, s):
         return s
 
 
-# Create simulation objects from a test list file
 def get_simulations(testlist, simulator):
+    """Create simulation objects from a test list file.
+
+    Args:
+        testlist: Path to a test list file. A test list file is a YAML
+            file describing a set of tests.
+        simulator: The simulator to use to run the tests. A test run on
+            a specific simulator defines a simulation.
+
+    Returns:
+        A list of `Simulation` objects. The list contains a
+            `Simulation` object for every test which supports the given
+            `simulator`. This object defines a simulation of the test on
+            that particular `simulator`.
+    """
     # Get tests from test list file
     testlist_path = Path(testlist).absolute()
     with open(testlist_path, 'r') as f:
@@ -88,13 +164,23 @@ def get_simulations(testlist, simulator):
     for test in tests:
         test['elf'] = testlist_path.parent / test['elf']
         if 'cmd' in test:
-            test['cmd'] = [resolve_relative_path(testlist_path.parent, arg) for arg in test['cmd']]
+            test['cmd'] = [_resolve_relative_path(testlist_path.parent, arg) for arg in test['cmd']]
     # Create simulation object for every test which supports the specified simulator
     simulations = [simulator.get_simulation(test) for test in tests if simulator.supports(test)]
     return simulations
 
 
 def print_summary(failed_sims, early_exit=False, dry_run=False):
+    """Print a summary of the simulation suite's exit status.
+
+    Args:
+        failed_sims: A list of failed simulations from the simulation
+            suite.
+        early_exit: Whether the simulation suite was configured to
+            terminate upon the first failing simulation.
+        dry_run: Whether the simulation suite was launched in dry run
+            mode.
+    """
     if not dry_run:
         header = f'==== Test summary {"(early exit)" if early_exit else ""} ===='
         cprint(header, attrs=['bold'])
@@ -117,6 +203,15 @@ def terminate_simulations():
 
 
 def run_simulations(simulations, n_procs=1, run_dir=None, dry_run=False, early_exit=False):
+    """Run simulations defined by a list of `Simulation` objects.
+
+    Args:
+        simulations: A list of `Simulation` objects as returned e.g. by
+            [sim_utils.get_simulations][].
+
+    Returns:
+        The number of failed simulations.
+    """
     # Register SIGTERM handler, used to gracefully terminate all simulation subprocesses
     signal.signal(signal.SIGTERM, lambda _, __: terminate_simulations())
 


### PR DESCRIPTION
- [x] `util/sim`: add per-simulation run directory and dry-run options
- [x] `util/sim`: add MkDocs documentation
- [x] `target`: selectively enable full RTL visibility and wave logging with `DEBUG=ON` flag
- [x] `util/container`: update to Python 3.9.12 (aligned with IIS installed version)
- [x] Drop commits marked with "REVERT"