### PR TITLE
`snrt_global_barrier` requires additional `snrt_cluster_hw_barrier`

### DIFF
--- a/sw/snRuntime/src/sync.h
+++ b/sw/snRuntime/src/sync.h
@@ -62,7 +62,7 @@ inline void snrt_cluster_hw_barrier() {
 /// Synchronize clusters globally with a global software barrier
 inline void snrt_global_barrier() {
     snrt_cluster_hw_barrier();
-    
+
     // Synchronize all DM cores in software
     if (snrt_is_dm_core()) {
         // Remember previous iteration

--- a/sw/snRuntime/src/sync.h
+++ b/sw/snRuntime/src/sync.h
@@ -61,6 +61,8 @@ inline void snrt_cluster_hw_barrier() {
 
 /// Synchronize clusters globally with a global software barrier
 inline void snrt_global_barrier() {
+    snrt_cluster_hw_barrier();
+    
     // Synchronize all DM cores in software
     if (snrt_is_dm_core()) {
         // Remember previous iteration


### PR DESCRIPTION
An additional `snrt_cluster_hw_barrier` is required before the DM cores synchronize. 

Currently, the DM cores do not know if the other compute cores have arrived at the barrier. For example if a compute core in cluster 0 is late arriving at the barrier, other clusters will not wait for this core.