### PR TITLE
sw: Add GEMM baselines without SSR & frep extensions

### DIFF
--- a/sw/blas/gemm/src/gemm.h
+++ b/sw/blas/gemm/src/gemm.h
@@ -1217,9 +1217,9 @@ void sc_st_gemm(precision_t prec, uint32_t expand, uint32_t setup_ssr,
             case FP64:
                 if (baseline) {
                     gemm_fp64_naive(frac_m, n, k, (double*)a + offsetA,
-                                       lda_strided, transa, (double*)b, ldb,
-                                       transb, (double*)c + offsetC,
-                                       ldc_strided, (double)beta);
+                                    lda_strided, transa, (double*)b, ldb,
+                                    transb, (double*)c + offsetC, ldc_strided,
+                                    (double)beta);
                 } else {
                     gemm_fp64_opt(frac_m, n, k, (double*)a + offsetA,
                                   lda_strided, transa, (double*)b, ldb, transb,
@@ -1230,8 +1230,8 @@ void sc_st_gemm(precision_t prec, uint32_t expand, uint32_t setup_ssr,
             case FP32:
                 if (baseline) {
                     gemm_fp32_baseline(frac_m, n, k, (float*)a + offsetA,
-                                       lda_strided, (float*)b, ldb, (float*)c + offsetC, ldc_strided,
-                                       beta);
+                                       lda_strided, (float*)b, ldb,
+                                       (float*)c + offsetC, ldc_strided, beta);
                 } else {
                     gemm_fp32_opt(frac_m, n, k, (float*)a + offsetA,
                                   lda_strided, (float*)b, ldb,

--- a/sw/blas/gemm/src/gemm.h
+++ b/sw/blas/gemm/src/gemm.h
@@ -1296,11 +1296,18 @@ void sc_st_gemm(precision_t prec, uint32_t expand, uint32_t setup_ssr,
                 }
                 break;
             case FP8:
-                gemm_fp8_ex_opt(frac_m, n, k, (char*)a + offsetA, lda, (char*)b,
+                if (baseline) {
+                    gemm_fp8_baseline(frac_m, n, k, (char*)a + offsetA, lda, (char*)b,
                                 ldb, (char*)c + offsetC, ldc_strided, &beta,
                                 setup_ssr);
+                } else {
+                    gemm_fp8_ex_opt(frac_m, n, k, (char*)a + offsetA, lda, (char*)b,
+                                ldb, (char*)c + offsetC, ldc_strided, &beta,
+                                setup_ssr);
+                }
                 break;
         }
+
     }
 }
 

--- a/sw/blas/gemm/src/gemm.h
+++ b/sw/blas/gemm/src/gemm.h
@@ -425,15 +425,6 @@ void gemm_fp32_baseline(const uint32_t M, const uint32_t N, const uint32_t K,
                   [ zero ] "f"(zero)
                 : "ft0", "ft1", "ft2", "ft3", "ft4", "t0");
         }
-
-        // Clean up of leftover columns
-        for (; n < N; n++) {
-            float c = (*BETA) ? C[m * ldC + n] : 0.0;
-            for (uint32_t k = 0; k < K; k++) {
-                c += A[k + m * ldA] * B[k + n * ldB];
-            }
-            C[m * ldC + n] = c;
-        }
     }
 }
 

--- a/sw/blas/gemm/src/gemm.h
+++ b/sw/blas/gemm/src/gemm.h
@@ -82,8 +82,8 @@ void gemm_fp32_naive(uint32_t M, uint32_t N, uint32_t K, float* A, uint32_t ldA,
 }
 
 void gemm_fp64_naive(uint32_t M, uint32_t N, uint32_t K, double* A,
-                        uint32_t ldA, uint32_t ta, double* B, uint32_t ldB,
-                        uint32_t tb, double* C, uint32_t ldC, double BETA) {
+                     uint32_t ldA, uint32_t ta, double* B, uint32_t ldB,
+                     uint32_t tb, double* C, uint32_t ldC, double BETA) {
     if (!ta && !tb) {
         for (uint32_t m = 0; m < M; m++) {
             for (uint32_t n = 0; n < N; n++) {
@@ -293,10 +293,10 @@ void gemm_fp64_opt(uint32_t M, uint32_t N, uint32_t K, double* A, uint32_t ldA,
                 "fmadd.d %[c5], ft0, ft1, %[c5] \n"
                 "fmadd.d %[c6], ft0, ft1, %[c6] \n"
                 "fmadd.d %[c7], ft0, ft1, %[c7] \n"
-                : [ c0 ] "+f"(c[0]), [ c1 ] "+f"(c[1]), [ c2 ] "+f"(c[2]),
-                  [ c3 ] "+f"(c[3]), [ c4 ] "+f"(c[4]), [ c5 ] "+f"(c[5]),
-                  [ c6 ] "+f"(c[6]), [ c7 ] "+f"(c[7])
-                : [ n_frep ] "r"(K - 1), [ unroll ] "i"(unroll)
+                : [c0] "+f"(c[0]), [c1] "+f"(c[1]), [c2] "+f"(c[2]),
+                  [c3] "+f"(c[3]), [c4] "+f"(c[4]), [c5] "+f"(c[5]),
+                  [c6] "+f"(c[6]), [c7] "+f"(c[7])
+                : [n_frep] "r"(K - 1), [unroll] "i"(unroll)
                 : "ft0", "ft1", "ft2");
 
             // Store results back
@@ -382,10 +382,9 @@ void gemm_fp32_baseline(const uint32_t M, const uint32_t N, const uint32_t K,
                 "vfsum.s ft2, ft3 \n"
                 // Store results
                 "fsw ft2, 0(%[C]) \n"
-                : [ a_ptr ] "+r"(a_ptr), [ b_ptr ] "+r"(b_ptr)
-                : [ c ] "f"(c), [ reduce_reg ] "f"(reduce_reg),
-                  [ C ] "r"(c_ptr), [ BETA ] "r"(BETA), [ K ] "r"(K),
-                  [ zero ] "f"(zero)
+                : [a_ptr] "+r"(a_ptr), [b_ptr] "+r"(b_ptr)
+                : [c] "f"(c), [reduce_reg] "f"(reduce_reg), [C] "r"(c_ptr),
+                  [BETA] "r"(BETA), [K] "r"(K), [zero] "f"(zero)
                 : "ft0", "ft1", "ft2", "ft3", "ft4", "t0");
         }
     }
@@ -500,19 +499,19 @@ void gemm_fp32_opt(const uint32_t M, const uint32_t N, const uint32_t K,
                 "vfcpka.s.s %[c1], %[reduce_reg2], %[reduce_reg3] \n"
                 "vfcpka.s.s %[c2], %[reduce_reg4], %[reduce_reg5] \n"
                 "vfcpka.s.s %[c3], %[reduce_reg6], %[reduce_reg7] \n"
-                : [ c0 ] "+f"(c[0]), [ c1 ] "+f"(c[1]), [ c2 ] "+f"(c[2]),
-                  [ c3 ] "+f"(c[3]), [ c4 ] "+f"(c[4]), [ c5 ] "+f"(c[5]),
-                  [ c6 ] "+f"(c[6]), [ c7 ] "+f"(c[7]),
-                  [ reduce_reg0 ] "+f"(reduce_reg[0]),
-                  [ reduce_reg1 ] "+f"(reduce_reg[1]),
-                  [ reduce_reg2 ] "+f"(reduce_reg[2]),
-                  [ reduce_reg3 ] "+f"(reduce_reg[3]),
-                  [ reduce_reg4 ] "+f"(reduce_reg[4]),
-                  [ reduce_reg5 ] "+f"(reduce_reg[5]),
-                  [ reduce_reg6 ] "+f"(reduce_reg[6]),
-                  [ reduce_reg7 ] "+f"(reduce_reg[7])
-                : [ C ] "r"(_C), [ zero ] "f"(zero), [ n_frep ] "r"(n_frep - 1),
-                  [ unroll ] "i"(unroll), [ BETA ] "r"(BETA)
+                : [c0] "+f"(c[0]), [c1] "+f"(c[1]), [c2] "+f"(c[2]),
+                  [c3] "+f"(c[3]), [c4] "+f"(c[4]), [c5] "+f"(c[5]),
+                  [c6] "+f"(c[6]), [c7] "+f"(c[7]),
+                  [reduce_reg0] "+f"(reduce_reg[0]),
+                  [reduce_reg1] "+f"(reduce_reg[1]),
+                  [reduce_reg2] "+f"(reduce_reg[2]),
+                  [reduce_reg3] "+f"(reduce_reg[3]),
+                  [reduce_reg4] "+f"(reduce_reg[4]),
+                  [reduce_reg5] "+f"(reduce_reg[5]),
+                  [reduce_reg6] "+f"(reduce_reg[6]),
+                  [reduce_reg7] "+f"(reduce_reg[7])
+                : [C] "r"(_C), [zero] "f"(zero), [n_frep] "r"(n_frep - 1),
+                  [unroll] "i"(unroll), [BETA] "r"(BETA)
                 : "ft0", "ft1", "ft2");
 
             // Store results
@@ -588,10 +587,9 @@ void gemm_fp16_baseline(uint32_t M, uint32_t N, uint32_t K, __fp16* A,
                 "vfcvt.h.s ft3, ft3\n"
                 // Store results
                 "fsh ft3, 0(%[C]) \n"
-                : [ a_ptr ] "+r"(a_ptr), [ b_ptr ] "+r"(b_ptr)
-                : [ c ] "f"(c), [ reduce_reg ] "f"(reduce_reg),
-                  [ C ] "r"(c_ptr), [ BETA ] "r"(BETA), [ K ] "r"(K),
-                  [ zero ] "f"(zero)
+                : [a_ptr] "+r"(a_ptr), [b_ptr] "+r"(b_ptr)
+                : [c] "f"(c), [reduce_reg] "f"(reduce_reg), [C] "r"(c_ptr),
+                  [BETA] "r"(BETA), [K] "r"(K), [zero] "f"(zero)
                 : "ft0", "ft1", "ft2", "ft3", "ft4", "t0");
         }
     }
@@ -743,19 +741,19 @@ void gemm_fp16_opt(uint32_t M, uint32_t N, uint32_t K, __fp16* A, uint32_t ldA,
                 "vfcpkb.h.s %[c0], %[c2], %[c3] \n"
                 "vfcpka.h.s %[c1], %[c4], %[c5] \n"
                 "vfcpkb.h.s %[c1], %[c6], %[c7] \n"
-                : [ c0 ] "+f"(c[0]), [ c1 ] "+f"(c[1]), [ c2 ] "+f"(c[2]),
-                  [ c3 ] "+f"(c[3]), [ c4 ] "+f"(c[4]), [ c5 ] "+f"(c[5]),
-                  [ c6 ] "+f"(c[6]), [ c7 ] "+f"(c[7]), [ beta ] "=r"(beta),
-                  [ reduce_reg0 ] "+f"(reduce_reg[0]),
-                  [ reduce_reg1 ] "+f"(reduce_reg[1]),
-                  [ reduce_reg2 ] "+f"(reduce_reg[2]),
-                  [ reduce_reg3 ] "+f"(reduce_reg[3]),
-                  [ reduce_reg4 ] "+f"(reduce_reg[4]),
-                  [ reduce_reg5 ] "+f"(reduce_reg[5]),
-                  [ reduce_reg6 ] "+f"(reduce_reg[6]),
-                  [ reduce_reg7 ] "+f"(reduce_reg[7])
-                : [ C ] "r"(_C), [ zero ] "f"(zero), [ n_frep ] "r"(n_frep),
-                  [ BETA ] "r"(BETA)
+                : [c0] "+f"(c[0]), [c1] "+f"(c[1]), [c2] "+f"(c[2]),
+                  [c3] "+f"(c[3]), [c4] "+f"(c[4]), [c5] "+f"(c[5]),
+                  [c6] "+f"(c[6]), [c7] "+f"(c[7]), [beta] "=r"(beta),
+                  [reduce_reg0] "+f"(reduce_reg[0]),
+                  [reduce_reg1] "+f"(reduce_reg[1]),
+                  [reduce_reg2] "+f"(reduce_reg[2]),
+                  [reduce_reg3] "+f"(reduce_reg[3]),
+                  [reduce_reg4] "+f"(reduce_reg[4]),
+                  [reduce_reg5] "+f"(reduce_reg[5]),
+                  [reduce_reg6] "+f"(reduce_reg[6]),
+                  [reduce_reg7] "+f"(reduce_reg[7])
+                : [C] "r"(_C), [zero] "f"(zero), [n_frep] "r"(n_frep),
+                  [BETA] "r"(BETA)
                 : "ft0", "ft1", "ft2");
 
             // Store results back
@@ -907,19 +905,19 @@ void gemm_fp16_ex_opt(uint32_t M, uint32_t N, uint32_t K, __fp16* A,
                 "vfcpkb.h.s %[c0], %[reduce_reg2], %[reduce_reg3] \n"
                 "vfcpka.h.s %[c1], %[reduce_reg4], %[reduce_reg5] \n"
                 "vfcpkb.h.s %[c1], %[reduce_reg6], %[reduce_reg7] \n"
-                : [ c0 ] "+f"(c[0]), [ c1 ] "+f"(c[1]), [ c2 ] "+f"(c[2]),
-                  [ c3 ] "+f"(c[3]), [ c4 ] "+f"(c[4]), [ c5 ] "+f"(c[5]),
-                  [ c6 ] "+f"(c[6]), [ c7 ] "+f"(c[7]), [ beta ] "=r"(beta),
-                  [ reduce_reg0 ] "+f"(reduce_reg[0]),
-                  [ reduce_reg1 ] "+f"(reduce_reg[1]),
-                  [ reduce_reg2 ] "+f"(reduce_reg[2]),
-                  [ reduce_reg3 ] "+f"(reduce_reg[3]),
-                  [ reduce_reg4 ] "+f"(reduce_reg[4]),
-                  [ reduce_reg5 ] "+f"(reduce_reg[5]),
-                  [ reduce_reg6 ] "+f"(reduce_reg[6]),
-                  [ reduce_reg7 ] "+f"(reduce_reg[7])
-                : [ C ] "r"(_C), [ zero ] "f"(zero), [ n_frep ] "r"(n_frep),
-                  [ unroll ] "i"(unroll), [ BETA ] "r"(BETA)
+                : [c0] "+f"(c[0]), [c1] "+f"(c[1]), [c2] "+f"(c[2]),
+                  [c3] "+f"(c[3]), [c4] "+f"(c[4]), [c5] "+f"(c[5]),
+                  [c6] "+f"(c[6]), [c7] "+f"(c[7]), [beta] "=r"(beta),
+                  [reduce_reg0] "+f"(reduce_reg[0]),
+                  [reduce_reg1] "+f"(reduce_reg[1]),
+                  [reduce_reg2] "+f"(reduce_reg[2]),
+                  [reduce_reg3] "+f"(reduce_reg[3]),
+                  [reduce_reg4] "+f"(reduce_reg[4]),
+                  [reduce_reg5] "+f"(reduce_reg[5]),
+                  [reduce_reg6] "+f"(reduce_reg[6]),
+                  [reduce_reg7] "+f"(reduce_reg[7])
+                : [C] "r"(_C), [zero] "f"(zero), [n_frep] "r"(n_frep),
+                  [unroll] "i"(unroll), [BETA] "r"(BETA)
                 : "ft0", "ft1", "ft2");
 
             // Store results back
@@ -991,10 +989,9 @@ void gemm_fp8_baseline(uint32_t M, uint32_t N, uint32_t K, char* A,
                 "vfcvt.b.s ft2, ft2\n"
                 // Store results
                 "fsb ft2, 0(%[C]) \n"
-                : [ a_ptr ] "+r"(a_ptr), [ b_ptr ] "+r"(b_ptr)
-                : [ c ] "f"(c), [ reduce_reg ] "f"(reduce_reg),
-                  [ C ] "r"(c_ptr), [ BETA ] "r"(BETA), [ K ] "r"(K),
-                  [ zero ] "f"(zero)
+                : [a_ptr] "+r"(a_ptr), [b_ptr] "+r"(b_ptr)
+                : [c] "f"(c), [reduce_reg] "f"(reduce_reg), [C] "r"(c_ptr),
+                  [BETA] "r"(BETA), [K] "r"(K), [zero] "f"(zero)
                 : "ft0", "ft1", "ft2", "ft3", "ft4", "t0");
         }
     }
@@ -1153,19 +1150,19 @@ void gemm_fp8_ex_opt(uint32_t M, uint32_t N, uint32_t K, char* A, uint32_t ldA,
                 // "vfcpkb.b.s %[c0], %[reduce_reg2], %[reduce_reg3] \n"
                 // "vfcpkc.b.s %[c0], %[reduce_reg4], %[reduce_reg5] \n"
                 // "vfcpkd.b.s %[c0], %[reduce_reg6], %[reduce_reg7] \n"
-                : [ c0 ] "+f"(c[0]), [ c1 ] "+f"(c[1]), [ c2 ] "+f"(c[2]),
-                  [ c3 ] "+f"(c[3]), [ c4 ] "+f"(c[4]), [ c5 ] "+f"(c[5]),
-                  [ c6 ] "+f"(c[6]), [ c7 ] "+f"(c[7]), [ beta ] "=r"(beta),
-                  [ reduce_reg0 ] "+f"(reduce_reg[0]),
-                  [ reduce_reg1 ] "+f"(reduce_reg[1]),
-                  [ reduce_reg2 ] "+f"(reduce_reg[2]),
-                  [ reduce_reg3 ] "+f"(reduce_reg[3]),
-                  [ reduce_reg4 ] "+f"(reduce_reg[4]),
-                  [ reduce_reg5 ] "+f"(reduce_reg[5]),
-                  [ reduce_reg6 ] "+f"(reduce_reg[6]),
-                  [ reduce_reg7 ] "+f"(reduce_reg[7])
-                : [ C ] "r"(_C), [ n_frep ] "r"(n_frep), [ BETA ] "r"(BETA),
-                  [ unroll ] "i"(unroll), [ zero ] "f"(zero)
+                : [c0] "+f"(c[0]), [c1] "+f"(c[1]), [c2] "+f"(c[2]),
+                  [c3] "+f"(c[3]), [c4] "+f"(c[4]), [c5] "+f"(c[5]),
+                  [c6] "+f"(c[6]), [c7] "+f"(c[7]), [beta] "=r"(beta),
+                  [reduce_reg0] "+f"(reduce_reg[0]),
+                  [reduce_reg1] "+f"(reduce_reg[1]),
+                  [reduce_reg2] "+f"(reduce_reg[2]),
+                  [reduce_reg3] "+f"(reduce_reg[3]),
+                  [reduce_reg4] "+f"(reduce_reg[4]),
+                  [reduce_reg5] "+f"(reduce_reg[5]),
+                  [reduce_reg6] "+f"(reduce_reg[6]),
+                  [reduce_reg7] "+f"(reduce_reg[7])
+                : [C] "r"(_C), [n_frep] "r"(n_frep), [BETA] "r"(BETA),
+                  [unroll] "i"(unroll), [zero] "f"(zero)
                 : "ft0", "ft1", "ft2");
 
             // Store results back
@@ -1260,17 +1257,16 @@ void sc_st_gemm(precision_t prec, uint32_t expand, uint32_t setup_ssr,
                 break;
             case FP8:
                 if (baseline) {
-                    gemm_fp8_baseline(frac_m, n, k, (char*)a + offsetA, lda, (char*)b,
-                                ldb, (char*)c + offsetC, ldc_strided, &beta,
-                                setup_ssr);
+                    gemm_fp8_baseline(frac_m, n, k, (char*)a + offsetA, lda,
+                                      (char*)b, ldb, (char*)c + offsetC,
+                                      ldc_strided, &beta, setup_ssr);
                 } else {
-                    gemm_fp8_ex_opt(frac_m, n, k, (char*)a + offsetA, lda, (char*)b,
-                                ldb, (char*)c + offsetC, ldc_strided, &beta,
-                                setup_ssr);
+                    gemm_fp8_ex_opt(frac_m, n, k, (char*)a + offsetA, lda,
+                                    (char*)b, ldb, (char*)c + offsetC,
+                                    ldc_strided, &beta, setup_ssr);
                 }
                 break;
         }
-
     }
 }
 

--- a/sw/blas/gemm/src/gemm.h
+++ b/sw/blas/gemm/src/gemm.h
@@ -35,9 +35,9 @@ static inline double multiply_opt(double multiplicand, double multiplier) {
         return 0;
 }
 
-void gemm_fp32_baseline(uint32_t M, uint32_t N, uint32_t K, float* A,
-                        uint32_t ldA, uint32_t ta, float* B, uint32_t ldB,
-                        uint32_t tb, float* C, uint32_t ldC, float BETA) {
+void gemm_fp32_naive(uint32_t M, uint32_t N, uint32_t K, float* A, uint32_t ldA,
+                     uint32_t ta, float* B, uint32_t ldB, uint32_t tb, float* C,
+                     uint32_t ldC, float BETA) {
     if (!ta && !tb) {
         for (uint32_t m = 0; m < M; m++) {
             for (uint32_t n = 0; n < N; n++) {
@@ -81,7 +81,7 @@ void gemm_fp32_baseline(uint32_t M, uint32_t N, uint32_t K, float* A,
     }
 }
 
-void gemm_fp64_baseline(uint32_t M, uint32_t N, uint32_t K, double* A,
+void gemm_fp64_naive(uint32_t M, uint32_t N, uint32_t K, double* A,
                         uint32_t ldA, uint32_t ta, double* B, uint32_t ldB,
                         uint32_t tb, double* C, uint32_t ldC, double BETA) {
     if (!ta && !tb) {
@@ -142,11 +142,10 @@ void gemm_fp64_baseline(uint32_t M, uint32_t N, uint32_t K, double* A,
  * BETA: scalar beta
  * A is MxK, B is KxN, C is MxN
  */
-void gemm_fp32_baseline_unrolled(uint32_t M, uint32_t N, uint32_t K, float* A,
-                                 uint32_t ldA, uint32_t ta, float* B,
-                                 uint32_t ldB, uint32_t tb, float* C,
-                                 uint32_t ldC, float BETA) {
     // float c0, c1, c2, c3 = 0;
+void gemm_fp32_naive_unrolled(uint32_t M, uint32_t N, uint32_t K, float* A,
+                              uint32_t ldA, uint32_t ta, float* B, uint32_t ldB,
+                              uint32_t tb, float* C, uint32_t ldC, float BETA) {
     float c0 = 0.0f;
     float c1 = 0.0f;
     float c2 = 0.0f;

--- a/sw/blas/gemm/src/gemm.h
+++ b/sw/blas/gemm/src/gemm.h
@@ -293,10 +293,10 @@ void gemm_fp64_opt(uint32_t M, uint32_t N, uint32_t K, double* A, uint32_t ldA,
                 "fmadd.d %[c5], ft0, ft1, %[c5] \n"
                 "fmadd.d %[c6], ft0, ft1, %[c6] \n"
                 "fmadd.d %[c7], ft0, ft1, %[c7] \n"
-                : [c0] "+f"(c[0]), [c1] "+f"(c[1]), [c2] "+f"(c[2]),
-                  [c3] "+f"(c[3]), [c4] "+f"(c[4]), [c5] "+f"(c[5]),
-                  [c6] "+f"(c[6]), [c7] "+f"(c[7])
-                : [n_frep] "r"(K - 1), [unroll] "i"(unroll)
+                : [ c0 ] "+f"(c[0]), [ c1 ] "+f"(c[1]), [ c2 ] "+f"(c[2]),
+                  [ c3 ] "+f"(c[3]), [ c4 ] "+f"(c[4]), [ c5 ] "+f"(c[5]),
+                  [ c6 ] "+f"(c[6]), [ c7 ] "+f"(c[7])
+                : [ n_frep ] "r"(K - 1), [ unroll ] "i"(unroll)
                 : "ft0", "ft1", "ft2");
 
             // Store results back
@@ -381,9 +381,10 @@ void gemm_fp32_baseline(const uint32_t M, const uint32_t N, const uint32_t K,
                 "vfsum.s ft2, ft3 \n"
                 // Store results
                 "fsw ft2, 0(%[C]) \n"
-                : [a_ptr] "+r"(a_ptr), [b_ptr] "+r"(b_ptr)
-                : [c] "f"(c), [reduce_reg] "f"(reduce_reg), [C] "r"(c_ptr),
-                  [BETA] "r"(BETA), [K] "r"(K), [zero] "f"(zero)
+                : [ a_ptr ] "+r"(a_ptr), [ b_ptr ] "+r"(b_ptr)
+                : [ c ] "f"(c), [ reduce_reg ] "f"(reduce_reg),
+                  [ C ] "r"(c_ptr), [ BETA ] "r"(BETA), [ K ] "r"(K),
+                  [ zero ] "f"(zero)
                 : "ft0", "ft1", "ft2", "ft3", "ft4", "t0");
         }
     }
@@ -498,19 +499,19 @@ void gemm_fp32_opt(const uint32_t M, const uint32_t N, const uint32_t K,
                 "vfcpka.s.s %[c1], %[reduce_reg2], %[reduce_reg3] \n"
                 "vfcpka.s.s %[c2], %[reduce_reg4], %[reduce_reg5] \n"
                 "vfcpka.s.s %[c3], %[reduce_reg6], %[reduce_reg7] \n"
-                : [c0] "+f"(c[0]), [c1] "+f"(c[1]), [c2] "+f"(c[2]),
-                  [c3] "+f"(c[3]), [c4] "+f"(c[4]), [c5] "+f"(c[5]),
-                  [c6] "+f"(c[6]), [c7] "+f"(c[7]),
-                  [reduce_reg0] "+f"(reduce_reg[0]),
-                  [reduce_reg1] "+f"(reduce_reg[1]),
-                  [reduce_reg2] "+f"(reduce_reg[2]),
-                  [reduce_reg3] "+f"(reduce_reg[3]),
-                  [reduce_reg4] "+f"(reduce_reg[4]),
-                  [reduce_reg5] "+f"(reduce_reg[5]),
-                  [reduce_reg6] "+f"(reduce_reg[6]),
-                  [reduce_reg7] "+f"(reduce_reg[7])
-                : [C] "r"(_C), [zero] "f"(zero), [n_frep] "r"(n_frep - 1),
-                  [unroll] "i"(unroll), [BETA] "r"(BETA)
+                : [ c0 ] "+f"(c[0]), [ c1 ] "+f"(c[1]), [ c2 ] "+f"(c[2]),
+                  [ c3 ] "+f"(c[3]), [ c4 ] "+f"(c[4]), [ c5 ] "+f"(c[5]),
+                  [ c6 ] "+f"(c[6]), [ c7 ] "+f"(c[7]),
+                  [ reduce_reg0 ] "+f"(reduce_reg[0]),
+                  [ reduce_reg1 ] "+f"(reduce_reg[1]),
+                  [ reduce_reg2 ] "+f"(reduce_reg[2]),
+                  [ reduce_reg3 ] "+f"(reduce_reg[3]),
+                  [ reduce_reg4 ] "+f"(reduce_reg[4]),
+                  [ reduce_reg5 ] "+f"(reduce_reg[5]),
+                  [ reduce_reg6 ] "+f"(reduce_reg[6]),
+                  [ reduce_reg7 ] "+f"(reduce_reg[7])
+                : [ C ] "r"(_C), [ zero ] "f"(zero), [ n_frep ] "r"(n_frep - 1),
+                  [ unroll ] "i"(unroll), [ BETA ] "r"(BETA)
                 : "ft0", "ft1", "ft2");
 
             // Store results
@@ -586,9 +587,10 @@ void gemm_fp16_baseline(uint32_t M, uint32_t N, uint32_t K, __fp16* A,
                 "vfcvt.h.s ft3, ft3\n"
                 // Store results
                 "fsh ft3, 0(%[C]) \n"
-                : [a_ptr] "+r"(a_ptr), [b_ptr] "+r"(b_ptr)
-                : [c] "f"(c), [reduce_reg] "f"(reduce_reg), [C] "r"(c_ptr),
-                  [BETA] "r"(BETA), [K] "r"(K), [zero] "f"(zero)
+                : [ a_ptr ] "+r"(a_ptr), [ b_ptr ] "+r"(b_ptr)
+                : [ c ] "f"(c), [ reduce_reg ] "f"(reduce_reg),
+                  [ C ] "r"(c_ptr), [ BETA ] "r"(BETA), [ K ] "r"(K),
+                  [ zero ] "f"(zero)
                 : "ft0", "ft1", "ft2", "ft3", "ft4", "t0");
         }
     }
@@ -740,19 +742,19 @@ void gemm_fp16_opt(uint32_t M, uint32_t N, uint32_t K, __fp16* A, uint32_t ldA,
                 "vfcpkb.h.s %[c0], %[c2], %[c3] \n"
                 "vfcpka.h.s %[c1], %[c4], %[c5] \n"
                 "vfcpkb.h.s %[c1], %[c6], %[c7] \n"
-                : [c0] "+f"(c[0]), [c1] "+f"(c[1]), [c2] "+f"(c[2]),
-                  [c3] "+f"(c[3]), [c4] "+f"(c[4]), [c5] "+f"(c[5]),
-                  [c6] "+f"(c[6]), [c7] "+f"(c[7]), [beta] "=r"(beta),
-                  [reduce_reg0] "+f"(reduce_reg[0]),
-                  [reduce_reg1] "+f"(reduce_reg[1]),
-                  [reduce_reg2] "+f"(reduce_reg[2]),
-                  [reduce_reg3] "+f"(reduce_reg[3]),
-                  [reduce_reg4] "+f"(reduce_reg[4]),
-                  [reduce_reg5] "+f"(reduce_reg[5]),
-                  [reduce_reg6] "+f"(reduce_reg[6]),
-                  [reduce_reg7] "+f"(reduce_reg[7])
-                : [C] "r"(_C), [zero] "f"(zero), [n_frep] "r"(n_frep),
-                  [BETA] "r"(BETA)
+                : [ c0 ] "+f"(c[0]), [ c1 ] "+f"(c[1]), [ c2 ] "+f"(c[2]),
+                  [ c3 ] "+f"(c[3]), [ c4 ] "+f"(c[4]), [ c5 ] "+f"(c[5]),
+                  [ c6 ] "+f"(c[6]), [ c7 ] "+f"(c[7]), [ beta ] "=r"(beta),
+                  [ reduce_reg0 ] "+f"(reduce_reg[0]),
+                  [ reduce_reg1 ] "+f"(reduce_reg[1]),
+                  [ reduce_reg2 ] "+f"(reduce_reg[2]),
+                  [ reduce_reg3 ] "+f"(reduce_reg[3]),
+                  [ reduce_reg4 ] "+f"(reduce_reg[4]),
+                  [ reduce_reg5 ] "+f"(reduce_reg[5]),
+                  [ reduce_reg6 ] "+f"(reduce_reg[6]),
+                  [ reduce_reg7 ] "+f"(reduce_reg[7])
+                : [ C ] "r"(_C), [ zero ] "f"(zero), [ n_frep ] "r"(n_frep),
+                  [ BETA ] "r"(BETA)
                 : "ft0", "ft1", "ft2");
 
             // Store results back
@@ -904,19 +906,19 @@ void gemm_fp16_ex_opt(uint32_t M, uint32_t N, uint32_t K, __fp16* A,
                 "vfcpkb.h.s %[c0], %[reduce_reg2], %[reduce_reg3] \n"
                 "vfcpka.h.s %[c1], %[reduce_reg4], %[reduce_reg5] \n"
                 "vfcpkb.h.s %[c1], %[reduce_reg6], %[reduce_reg7] \n"
-                : [c0] "+f"(c[0]), [c1] "+f"(c[1]), [c2] "+f"(c[2]),
-                  [c3] "+f"(c[3]), [c4] "+f"(c[4]), [c5] "+f"(c[5]),
-                  [c6] "+f"(c[6]), [c7] "+f"(c[7]), [beta] "=r"(beta),
-                  [reduce_reg0] "+f"(reduce_reg[0]),
-                  [reduce_reg1] "+f"(reduce_reg[1]),
-                  [reduce_reg2] "+f"(reduce_reg[2]),
-                  [reduce_reg3] "+f"(reduce_reg[3]),
-                  [reduce_reg4] "+f"(reduce_reg[4]),
-                  [reduce_reg5] "+f"(reduce_reg[5]),
-                  [reduce_reg6] "+f"(reduce_reg[6]),
-                  [reduce_reg7] "+f"(reduce_reg[7])
-                : [C] "r"(_C), [zero] "f"(zero), [n_frep] "r"(n_frep),
-                  [unroll] "i"(unroll), [BETA] "r"(BETA)
+                : [ c0 ] "+f"(c[0]), [ c1 ] "+f"(c[1]), [ c2 ] "+f"(c[2]),
+                  [ c3 ] "+f"(c[3]), [ c4 ] "+f"(c[4]), [ c5 ] "+f"(c[5]),
+                  [ c6 ] "+f"(c[6]), [ c7 ] "+f"(c[7]), [ beta ] "=r"(beta),
+                  [ reduce_reg0 ] "+f"(reduce_reg[0]),
+                  [ reduce_reg1 ] "+f"(reduce_reg[1]),
+                  [ reduce_reg2 ] "+f"(reduce_reg[2]),
+                  [ reduce_reg3 ] "+f"(reduce_reg[3]),
+                  [ reduce_reg4 ] "+f"(reduce_reg[4]),
+                  [ reduce_reg5 ] "+f"(reduce_reg[5]),
+                  [ reduce_reg6 ] "+f"(reduce_reg[6]),
+                  [ reduce_reg7 ] "+f"(reduce_reg[7])
+                : [ C ] "r"(_C), [ zero ] "f"(zero), [ n_frep ] "r"(n_frep),
+                  [ unroll ] "i"(unroll), [ BETA ] "r"(BETA)
                 : "ft0", "ft1", "ft2");
 
             // Store results back
@@ -988,9 +990,10 @@ void gemm_fp8_baseline(uint32_t M, uint32_t N, uint32_t K, char* A,
                 "vfcvt.b.s ft2, ft2\n"
                 // Store results
                 "fsb ft2, 0(%[C]) \n"
-                : [a_ptr] "+r"(a_ptr), [b_ptr] "+r"(b_ptr)
-                : [c] "f"(c), [reduce_reg] "f"(reduce_reg), [C] "r"(c_ptr),
-                  [BETA] "r"(BETA), [K] "r"(K), [zero] "f"(zero)
+                : [ a_ptr ] "+r"(a_ptr), [ b_ptr ] "+r"(b_ptr)
+                : [ c ] "f"(c), [ reduce_reg ] "f"(reduce_reg),
+                  [ C ] "r"(c_ptr), [ BETA ] "r"(BETA), [ K ] "r"(K),
+                  [ zero ] "f"(zero)
                 : "ft0", "ft1", "ft2", "ft3", "ft4", "t0");
         }
     }
@@ -1149,19 +1152,19 @@ void gemm_fp8_ex_opt(uint32_t M, uint32_t N, uint32_t K, char* A, uint32_t ldA,
                 // "vfcpkb.b.s %[c0], %[reduce_reg2], %[reduce_reg3] \n"
                 // "vfcpkc.b.s %[c0], %[reduce_reg4], %[reduce_reg5] \n"
                 // "vfcpkd.b.s %[c0], %[reduce_reg6], %[reduce_reg7] \n"
-                : [c0] "+f"(c[0]), [c1] "+f"(c[1]), [c2] "+f"(c[2]),
-                  [c3] "+f"(c[3]), [c4] "+f"(c[4]), [c5] "+f"(c[5]),
-                  [c6] "+f"(c[6]), [c7] "+f"(c[7]), [beta] "=r"(beta),
-                  [reduce_reg0] "+f"(reduce_reg[0]),
-                  [reduce_reg1] "+f"(reduce_reg[1]),
-                  [reduce_reg2] "+f"(reduce_reg[2]),
-                  [reduce_reg3] "+f"(reduce_reg[3]),
-                  [reduce_reg4] "+f"(reduce_reg[4]),
-                  [reduce_reg5] "+f"(reduce_reg[5]),
-                  [reduce_reg6] "+f"(reduce_reg[6]),
-                  [reduce_reg7] "+f"(reduce_reg[7])
-                : [C] "r"(_C), [n_frep] "r"(n_frep), [BETA] "r"(BETA),
-                  [unroll] "i"(unroll), [zero] "f"(zero)
+                : [ c0 ] "+f"(c[0]), [ c1 ] "+f"(c[1]), [ c2 ] "+f"(c[2]),
+                  [ c3 ] "+f"(c[3]), [ c4 ] "+f"(c[4]), [ c5 ] "+f"(c[5]),
+                  [ c6 ] "+f"(c[6]), [ c7 ] "+f"(c[7]), [ beta ] "=r"(beta),
+                  [ reduce_reg0 ] "+f"(reduce_reg[0]),
+                  [ reduce_reg1 ] "+f"(reduce_reg[1]),
+                  [ reduce_reg2 ] "+f"(reduce_reg[2]),
+                  [ reduce_reg3 ] "+f"(reduce_reg[3]),
+                  [ reduce_reg4 ] "+f"(reduce_reg[4]),
+                  [ reduce_reg5 ] "+f"(reduce_reg[5]),
+                  [ reduce_reg6 ] "+f"(reduce_reg[6]),
+                  [ reduce_reg7 ] "+f"(reduce_reg[7])
+                : [ C ] "r"(_C), [ n_frep ] "r"(n_frep), [ BETA ] "r"(BETA),
+                  [ unroll ] "i"(unroll), [ zero ] "f"(zero)
                 : "ft0", "ft1", "ft2");
 
             // Store results back

--- a/sw/blas/gemm/src/gemm.h
+++ b/sw/blas/gemm/src/gemm.h
@@ -579,6 +579,61 @@ void gemm_fp32_opt(const uint32_t M, const uint32_t N, const uint32_t K,
     snrt_ssr_disable();
 }
 
+void gemm_fp16_baseline(uint32_t M, uint32_t N, uint32_t K, __fp16* A,
+                        uint32_t ldA, __fp16* B, uint32_t ldB, __fp16* C,
+                        uint32_t ldC, const uint32_t* BETA,
+                        uint32_t setup_SSR) {
+    for (uint32_t m = 0; m < M; m++) {
+        uint32_t n = 0;
+        for (; n < N; n++) {
+            volatile register v4f16 *a_ptr, *b_ptr;
+            register v4f16 a, b;
+            volatile __fp16* c_ptr;
+            const register float zero = 0.0;
+            double c = 0.0;
+            v4f16 reduce_reg;
+
+            a_ptr = (v4f16*)(&A[m * ldA]);
+            b_ptr = (v4f16*)(&B[n * ldB]);
+            c_ptr = &C[m * ldC + n];
+            // Don't accumulate in first iteration
+            asm volatile(
+                "lw      t0, 0(%[BETA]) \n"
+                "beqz    t0, 1f \n"
+                // Load intermediate results
+                "flh ft2, 0(%[C]) \n"
+                "vfcvt.s.h ft2, ft2\n"
+                "vfcpka.s.s ft2, ft2, %[zero]\n"
+                // or initialize with zero
+                "j 2f \n"
+                "1: \n"
+                "vfcpka.s.s ft2, %[zero], %[zero]\n"
+                "2: \n"
+                // loop over the MACs
+                "li     t0, 0 \n"
+                "3: \n"
+                "fld ft0, 0(%[a_ptr]) \n"
+                "fld ft1, 0(%[b_ptr]) \n"
+                "add %[a_ptr], %[a_ptr], 8 \n"
+                "add %[b_ptr], %[b_ptr], 8 \n"
+                "vfdotpex.s.h ft2, ft0, ft1 \n"
+                "addi  t0, t0, 4 \n"
+                "blt   t0, %[K], 3b \n"
+                // Sum reduce vector
+                "vfcpka.s.s ft3, %[zero], %[zero]\n"
+                "vfsum.s ft3, ft2 \n"
+                "vfcvt.h.s ft3, ft3\n"
+                // Store results
+                "fsh ft3, 0(%[C]) \n"
+                : [ a_ptr ] "+r"(a_ptr), [ b_ptr ] "+r"(b_ptr)
+                : [ c ] "f"(c), [ reduce_reg ] "f"(reduce_reg),
+                  [ C ] "r"(c_ptr), [ BETA ] "r"(BETA), [ K ] "r"(K),
+                  [ zero ] "f"(zero)
+                : "ft0", "ft1", "ft2", "ft3", "ft4", "t0");
+        }
+    }
+}
+
 void gemm_fp16_opt(uint32_t M, uint32_t N, uint32_t K, __fp16* A, uint32_t ldA,
                    __fp16* B, uint32_t ldB, __fp16* C, uint32_t ldC,
                    const uint32_t* BETA, uint32_t setup_SSR) {

--- a/sw/blas/gemm/verify.py
+++ b/sw/blas/gemm/verify.py
@@ -59,7 +59,7 @@ def main():
     c_golden = golden_model(1, a, b, beta, c).flatten()
 
     absolute_err = np.absolute(c_golden - c_actual)
-    fail = np.any(absolute_err > ERR_THRESHOLD)
+    fail = np.any(absolute_err > ERR_THRESHOLD[prec])
     if (fail):
         print('Simulation results are incorrect.')
         verification.dump_results_to_csv([c_golden, c_actual, absolute_err],

--- a/sw/blas/gemm/verify.py
+++ b/sw/blas/gemm/verify.py
@@ -21,18 +21,6 @@ ERR_THRESHOLD = {8: 1e-6, 4: 1e-6, 2: 1e-2, 1: 1e-1}
 NP_DTYPE = {8: np.float64, 4: np.float32, 2: np.float16, 1: np.uint8}
 
 
-def fp8byte_to_float(byte: np.uint8):
-    """Converts a number from a byte stored as a uint8 to a float."""
-    sign = (byte & 0x80) >> 7  # Extract sign (1 bit)
-    exponent = (byte & 0x7c) >> 2  # Extract exponent (5 bits)
-    mantissa = (byte & 0x03) << 5  # Extract mantissa (2 bits)
-    real_exp = exponent - 15  # Convert exponent from excess-7 to excess-127
-    value = (1 + mantissa / 4) * (2 ** float(real_exp))  # Calculate value
-    if sign:
-        value *= -1
-    return value
-
-
 def main():
     # Run simulation and get outputs
     args = verification.parse_args()

--- a/sw/blas/gemm/verify.py
+++ b/sw/blas/gemm/verify.py
@@ -18,8 +18,6 @@ from data_utils import from_buffer, ctype_from_precision_t  # noqa: E402
 
 ERR_THRESHOLD = {8: 1e-6, 4: 1e-6, 2: 1e-2, 1: 1e-1}
 
-NP_DTYPE = {8: np.float64, 4: np.float32, 2: np.float16, 1: np.uint8}
-
 
 def main():
     # Run simulation and get outputs

--- a/sw/blas/gemm/verify.py
+++ b/sw/blas/gemm/verify.py
@@ -20,6 +20,7 @@ ERR_THRESHOLD = {8: 1e-6, 4: 1e-6, 2: 1e-2, 1: 1e-1}
 
 NP_DTYPE = {8: np.float64, 4: np.float32, 2: np.float16, 1: np.uint8}
 
+
 def fp8byte_to_float(byte: np.uint8):
     """Converts a number from a byte stored as a uint8 to a float."""
     sign = (byte & 0x80) >> 7  # Extract sign (1 bit)


### PR DESCRIPTION
To compare the performance of the `Xssr` and `Xfrep` extensions, this PR adds baseline (optimized) GEMM kernels.