### PR TITLE
hw: Fix repeated load-stores in FPSS on WAW stall

### DIFF
--- a/hw/snitch_cluster/src/snitch_fp_ss.sv
+++ b/hw/snitch_cluster/src/snitch_fp_ss.sv
@@ -2580,7 +2580,7 @@ module snitch_fp_ss import snitch_pkg::*; #(
   // ----------------------
   // Load/Store Unit
   // ----------------------
-  assign lsu_qvalid = acc_req_valid_q & (&op_ready) & (is_load | is_store);
+  assign lsu_qvalid = acc_req_valid_q & (&op_ready) & (is_load | is_store) & dst_ready;
 
   snitch_lsu #(
     .AddrWidth (AddrWidth),


### PR DESCRIPTION
Sometimes, when the floating-point subsystem is stalled on a load/store, it may issue it multiple times.

Since the `lsu_qvalid` and `lsu_qready` signals ignore `dst_ready`, it may occur, when `dst_ready` is 0, that we have a handshake on the LSU request interface (`lsu_qvalid && lsu_qready`), without the same handshake being propagated to the accelerator request interface, as `acc_req_ready_q` depends on `dst_ready`. Therefore, `lsu_qvalid`, which depends on `acc_req_valid_q`, will remain asserted, and repeated issues may occur.

This PR fixes this issue by only asserting `lsu_qvalid` when `dst_ready` is high.