### PR TITLE
cfg: Fix OmegaNet configuration for alias test

### DIFF
--- a/target/snitch_cluster/cfg/default.hjson
+++ b/target/snitch_cluster/cfg/default.hjson
@@ -37,7 +37,7 @@
             lat_noncomp: 1,
             lat_conv: 2,
             lat_sdotp: 3,
-            fpu_pipe_config: "BEFORE"
+            fpu_pipe_config: "BEFORE",
             narrow_xbar_latency: "CUT_ALL_PORTS",
             wide_xbar_latency: "CUT_ALL_PORTS",
             // Isolate the core.
@@ -107,10 +107,10 @@
     dma_core_template: {
         isa: "rv32imafd",
         // Xdiv_sqrt: true,
-        # isa: "rv32ema",
-        xdma: true
-        xssr: false
-        xfrep: false
+        // isa: "rv32ema",
+        xdma: true,
+        xssr: false,
+        xfrep: false,
         xf16: false,
         xf16alt: false,
         xf8: false,

--- a/target/snitch_cluster/cfg/fdiv.hjson
+++ b/target/snitch_cluster/cfg/fdiv.hjson
@@ -22,6 +22,7 @@
         },
         cluster_periph_size: 64, // kB
         zero_mem_size: 64, // kB
+        alias_region_enable: true,
         dma_data_width: 512,
         dma_axi_req_fifo_depth: 3,
         dma_req_fifo_depth: 3,

--- a/target/snitch_cluster/cfg/omega.hjson
+++ b/target/snitch_cluster/cfg/omega.hjson
@@ -23,6 +23,7 @@
         },
         cluster_periph_size: 64, // kB
         zero_mem_size: 64, // kB
+        alias_region_enable: true,
         dma_data_width: 512,
         dma_axi_req_fifo_depth: 3,
         dma_req_fifo_depth: 3,
@@ -37,7 +38,7 @@
             lat_noncomp: 1,
             lat_conv: 2,
             lat_sdotp: 3,
-            fpu_pipe_config: "BEFORE"
+            fpu_pipe_config: "BEFORE",
             narrow_xbar_latency: "CUT_ALL_PORTS",
             wide_xbar_latency: "CUT_ALL_PORTS",
             // Isolate the core.
@@ -107,10 +108,10 @@
     dma_core_template: {
         isa: "rv32imafd",
         // Xdiv_sqrt: true,
-        # isa: "rv32ema",
-        xdma: true
-        xssr: false
-        xfrep: false
+        // isa: "rv32ema",
+        xdma: true,
+        xssr: false,
+        xfrep: false,
         xf16: false,
         xf16alt: false,
         xf8: false,


### PR DESCRIPTION
Before merging https://github.com/pulp-platform/snitch_cluster/pull/94, we did not rebase manually on main. Before it, we merged https://github.com/pulp-platform/snitch_cluster/pull/52, which added the `alias` test which went untested in the CI of https://github.com/pulp-platform/snitch_cluster/pull/94. Indeed, that test does not pass because the configuration file for the Snitch cluster with Omega network does not enable aliasing.

This PR fixes this. Additionally it introduces some minor changes to the syntax of the configuration files, to transition towards json5 in place of hjson.