### PR TITLE
treewide: Add nonfree directory and CI jobs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,9 @@
-.bender/
-Bender.lock
-.vscode/
-__pycache__
+# Nonfree repository
+/nonfree/
+
+# Dependency files
+/.bender/
+/Bender.lock
 
 # Modelsim Files
 *.wlf
@@ -9,6 +11,9 @@ modelsim.ini
 *stacktrace*
 transcript
 
+# Miscellaneous
+.vscode/
+__pycache__
 gmon.out
 
 # Docs

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -135,3 +135,12 @@ snitch-cluster-omega-vsim:
     - make CFG_OVERRIDE=cfg/omega.hjson sw
     - make bin/snitch_cluster.vsim
     - ./run.py sw/run.yaml --simulator vsim -j --run-dir runs/vsim
+
+############
+# Non-free #
+############
+
+nonfree:
+  script:
+    - make nonfree
+    - make elab

--- a/Makefile
+++ b/Makefile
@@ -2,17 +2,59 @@
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
+###############
+# Executables #
+###############
+
 BENDER ?= bender
 REGGEN  = $(shell $(BENDER) path register_interface)/vendor/lowrisc_opentitan/util/regtool.py
+
+#########################
+# Files and directories #
+#########################
+
+ROOT = $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
+
+#######################
+# Global Make targets #
+#######################
+
+.PHONY: all
+.PHONY: clean
+
+############
+# Non-free #
+############
+
+NONFREE_REMOTE ?= git@iis-git.ee.ethz.ch:pulp-restricted/snitch-cluster-nonfree.git
+NONFREE_COMMIT ?= e30961e20a23a76442da27d2ba07c9fe20f3b575
+NONFREE_DIR = $(ROOT)/nonfree
+
+all: nonfree
+clean: clean-nonfree
+.PHONY: nonfree clean-nonfree
+
+nonfree: $(NONFREE_DIR)
+
+$(NONFREE_DIR):
+	git clone $(NONFREE_REMOTE) $(NONFREE_DIR)
+	cd $(NONFREE_DIR) && git checkout $(NONFREE_COMMIT)
+
+clean-nonfree:
+	rm -rf $(NONFREE_DIR)
+
+-include $(NONFREE_DIR)/Makefile
+
+########
+# Docs #
+########
 
 GENERATED_DOCS_DIR = docs/generated
 GENERATED_DOC_SRCS = $(GENERATED_DOCS_DIR)/peripherals.md
 
-.PHONY: all doc-srcs docs
-.PHONY: clean clean-docs
-
 all: docs
 clean: clean-docs
+.PHONY: doc-srcs docs clean-docs
 
 doc-srcs: $(GENERATED_DOC_SRCS)
 


### PR DESCRIPTION
Adds the `make nonfree` target to clone the non-free repository, and extends the CI to run non-free elaboration job.