### PR TITLE
sim: Support non-default logs directory

### DIFF
--- a/hw/snitch_cluster/src/snitch_cc.sv
+++ b/hw/snitch_cluster/src/snitch_cc.sv
@@ -855,6 +855,7 @@ module snitch_cc #(
   // pragma translate_off
   int f;
   string fn;
+  string logs_dir, mkdir_cmd;
   logic [63:0] cycle = 0;
   initial begin
     // We need to schedule the assignment into a safe region, otherwise
@@ -863,8 +864,12 @@ module snitch_cc #(
     /* verilator lint_off STMTDLY */
     #0;
     /* verilator lint_on STMTDLY */
-    $system("mkdir logs -p");
-    $sformat(fn, "logs/trace_hart_%05x.dasm", hart_id_i);
+    if (!$value$plusargs("LOGS_DIR=%s", logs_dir)) begin
+      logs_dir = "logs";
+    end
+    mkdir_cmd = $sformatf("mkdir -p %s", logs_dir);
+    $system(mkdir_cmd);
+    $sformat(fn, "%s/trace_hart_%05x.dasm", logs_dir, hart_id_i);
     f = $fopen(fn, "w");
     $display("[Tracer] Logging Hart %d to %s", hart_id_i, fn);
   end

--- a/target/common/common.mk
+++ b/target/common/common.mk
@@ -9,7 +9,7 @@ DEBUG ?= OFF  # ON to turn on wave logging
 SIM_DIR  ?= $(shell pwd)
 TB_DIR   ?= $(SNITCH_ROOT)/target/common/test
 UTIL_DIR ?= $(SNITCH_ROOT)/util
-LOGS_DIR  = $(SIM_DIR)/logs
+LOGS_DIR ?= $(SIM_DIR)/logs
 
 # Files
 BENDER_LOCK ?= $(ROOT)/Bender.lock


### PR DESCRIPTION
Mostly useful for multiple measurement simulations in parallel without overwritting the traces needed for performance measurements. Can also be used in conjunction with custom build directory, to build multiple similar binaries (e.g. with different problem dimensions) 

To be used like this:

```bash
# build app in separate folder (optional)
make sw APP_BUILDDIR=my_build
# Run the simulation
./bin/snitch_cluster.vsim sw/path/to/my_build/app.elf "" +LOGS_DIR=my_logs
# make the traces
make traces LOGS_DIR=my_logs
```