### PR TITLE
common: Add `clean-vsim` target and align AXPY to Occamy

### DIFF
--- a/sw/blas/axpy/data/params.json
+++ b/sw/blas/axpy/data/params.json
@@ -3,5 +3,5 @@
 // SPDX-License-Identifier: Apache-2.0
 
 {
-    n: 24
+    n: 384
 }

--- a/target/common/vsim.mk
+++ b/target/common/vsim.mk
@@ -39,3 +39,5 @@ $(BIN_DIR)/$(TARGET).vsim: $(VSIM_BUILDDIR)/compile.vsim.tcl $(VSIM_SOURCES) $(T
 .PHONY: clean-vsim
 clean-vsim: clean-work
 	rm -rf $(BIN_DIR)/$(TARGET).vsim $(BIN_DIR)/$(TARGET).vsim.gui $(VSIM_BUILDDIR) vsim.wlf
+
+clean: clean-vsim

--- a/target/snitch_cluster/Makefile
+++ b/target/snitch_cluster/Makefile
@@ -16,7 +16,7 @@ SELECT_RUNTIME ?=      # Select snRuntime implementation: "banshee" or "rtl" (de
 .DEFAULT_GOAL := help
 .PHONY: all clean
 all: sw
-clean: clean-sw clean-work clean-vsim clean-vlt clean-vcs clean-logs clean-bender clean-generated
+clean: clean-sw clean-work clean-vlt clean-vcs clean-logs clean-bender clean-generated
 
 ##########
 # Common #


### PR DESCRIPTION
This adds a `clean` target for the VSIM Makefile for compatibility with the Occamy `make clean` target. 