### PR TITLE
GEMM: Add switch cases for different GEMM flavors.  

### DIFF
--- a/sw/blas/gemm/data/params.json
+++ b/sw/blas/gemm/data/params.json
@@ -18,5 +18,5 @@
     n_tiles: 1, // number of tiles in N dimension
     parallelize_k: 0,
     parallelize_m: 0,
-    baseline: false
+    implementation: "BASELINE"
 }

--- a/sw/blas/gemm/data/params.json
+++ b/sw/blas/gemm/data/params.json
@@ -18,5 +18,5 @@
     n_tiles: 1, // number of tiles in N dimension
     parallelize_k: 0,
     parallelize_m: 0,
-    implementation: "BASELINE"
+    implementation: "NAIVE"
 }

--- a/sw/blas/gemm/scripts/datagen.py
+++ b/sw/blas/gemm/scripts/datagen.py
@@ -56,6 +56,17 @@ def validate_config(prec, implementation, parallelize_m, parallelize_k, m_tiles,
         ' greater or equal to the unrolling' \
         ' factor (8) when using optimized kernels'
     assert prec == "FP64" or beta == 0, 'beta != 0 supported only in FP64'
+    assert not (prec == "FP64" and implementation == "BASELINE"), 'No baseline implemented' \
+                                                                  ' for FP64 (switch to NAIVE)'
+    assert not (((prec == "FP64") or (prec == "FP32")) and implementation == "OPT_EX"), \
+        'Expanding GEMM kernels' \
+        ' not supported for FP64 and FP32'
+    assert not (((prec == "FP16") or (prec == "FP8")) and implementation == "NAIVE"), \
+        'FP16 and FP8 not supported' \
+        ' in naive implementation'
+    assert not (prec == "FP8" and implementation == "OPT"), 'FP8 not supported in' \
+                                                            ' optimized implementation' \
+                                                            ' (switch to OPT_EX)'
 
 
 def emit_header(**kwargs):

--- a/sw/blas/gemm/scripts/datagen.py
+++ b/sw/blas/gemm/scripts/datagen.py
@@ -44,15 +44,17 @@ def validate_config(prec, implementation, parallelize_m, parallelize_k, m_tiles,
                               ' cluster'
     assert not (parallelize_m and parallelize_k), 'Cannot parallelize K and M simultaneously'
     assert not ta, 'SIMD kernels don\'t support transposed A matrix'
-    assert not ((prec != "FP64") and (implementation != "BASELINE") and not tb), 'Optimized SIMD \
-            kernels support only non-transposed B matrix'
+    assert not ((prec != "FP64") and ((implementation != "BASELINE") or
+                                      (implementation != "NAIVE")) and not tb), \
+        'Optimized SIMD kernels support only transposed B matrix'
     assert not tb or n_tiles == 1, 'Tiling in the N dimension supported only if B is' \
                                    ' not transposed'
     assert not tb or k_tiles == 1, 'Tiling in the K dimension supported only if B is' \
                                    ' not transposed'
-    assert (implementation == "BASELINE") or frac_n >= 8, 'N dimension of tile size must be' \
-                                                          ' greater or equal to the unrolling' \
-                                                          ' factor (8) when using optimized kernels'
+    assert (implementation != "BASELINE") or (implementation != "NAIVE") or frac_n >= 8, \
+        'N dimension of tile size must be' \
+        ' greater or equal to the unrolling' \
+        ' factor (8) when using optimized kernels'
     assert prec == "FP64" or beta == 0, 'beta != 0 supported only in FP64'
 
 

--- a/sw/blas/gemm/scripts/datagen.py
+++ b/sw/blas/gemm/scripts/datagen.py
@@ -50,8 +50,9 @@ def validate_config(prec, implementation, parallelize_m, parallelize_k, m_tiles,
                                    ' not transposed'
     assert not tb or k_tiles == 1, 'Tiling in the K dimension supported only if B is' \
                                    ' not transposed'
-    assert implementation or frac_n >= 8, 'N dimension of tile size must be greater or equal to' \
-                                          ' the unrolling factor (8) when using optimized kernels'
+    assert (implementation == "BASELINE") or frac_n >= 8, 'N dimension of tile size must be' \
+                                                          ' greater or equal to the unrolling' \
+                                                          ' factor (8) when using optimized kernels'
     assert prec == "FP64" or beta == 0, 'beta != 0 supported only in FP64'
 
 

--- a/sw/blas/gemm/src/gemm.h
+++ b/sw/blas/gemm/src/gemm.h
@@ -83,7 +83,6 @@ void sc_st_gemm(precision_t prec, uint32_t expand, uint32_t setup_ssr,
                                         transb, (double*)c + offsetC,
                                         ldc_strided, (double)beta);
                         break;
-                        break;
                     case NAIVE_UNROLLED:
                         printf(
                             "Naive unrolled implementation not supported for "
@@ -98,9 +97,10 @@ void sc_st_gemm(precision_t prec, uint32_t expand, uint32_t setup_ssr,
                                       lda_strided, transa, (double*)b, ldb,
                                       transb, (double*)c + offsetC, ldc_strided,
                                       &beta, setup_ssr);
+                        break;
                     case OPT_EX:
                         printf(
-                            "Extended opt implementation not supported for "
+                            "Expanding opt implementation not supported for "
                             "FP64\n");
                         break;
                 }
@@ -133,7 +133,7 @@ void sc_st_gemm(precision_t prec, uint32_t expand, uint32_t setup_ssr,
                         break;
                     case OPT_EX:
                         printf(
-                            "Extended opt implementation not supported for "
+                            "Expanding opt implementation not supported for "
                             "FP32\n");
                         break;
                 }

--- a/sw/blas/gemm/src/gemm.h
+++ b/sw/blas/gemm/src/gemm.h
@@ -171,9 +171,10 @@ void sc_st_gemm(precision_t prec, uint32_t expand, uint32_t setup_ssr,
             case FP8:
                 switch (impl) {
                     case NAIVE:
-                        gemm_fp8_naive(
-                            frac_m, n, k, (char*)a + offsetA, lda_strided, (char*)b,
-                            ldb, (char*)c + offsetC, ldc_strided, (float)beta);
+                        gemm_fp8_naive(frac_m, n, k, (char*)a + offsetA,
+                                       lda_strided, (char*)b, ldb,
+                                       (char*)c + offsetC, ldc_strided,
+                                       (float)beta);
                         break;
                     case NAIVE_UNROLLED:
                         printf(
@@ -181,9 +182,10 @@ void sc_st_gemm(precision_t prec, uint32_t expand, uint32_t setup_ssr,
                             "FP8\n");
                         break;
                     case BASELINE:
-                        gemm_fp8_baseline(frac_m, n, k, (char*)a + offsetA, lda_strided,
-                                          (char*)b, ldb, (char*)c + offsetC,
-                                          ldc_strided, (float)beta);
+                        gemm_fp8_baseline(frac_m, n, k, (char*)a + offsetA,
+                                          lda_strided, (char*)b, ldb,
+                                          (char*)c + offsetC, ldc_strided,
+                                          (float)beta);
                         break;
                     case OPT:
                         printf(
@@ -215,7 +217,7 @@ int gemm(precision_t prec, uint32_t expand, uint32_t setup_ssr,
          uint32_t n_tiles, uint32_t k_tiles, uint32_t load_a, uint32_t load_b,
          uint32_t load_c, uint32_t transa, uint32_t transb, uint32_t m,
          uint32_t n, uint32_t k, double alpha, void* a, void* b, uint32_t beta,
-         void* c, uint32_t baseline) {
+         void* c, implementation_t implementation) {
     // Calculate tile sizes
     uint32_t frac_m = m / m_tiles;
     uint32_t frac_n = n / n_tiles;
@@ -325,7 +327,7 @@ int gemm(precision_t prec, uint32_t expand, uint32_t setup_ssr,
 
                     sc_st_gemm(prec, expand, setup_ssr, transa, transb, frac_m,
                                frac_n, frac_k, 1, local_a, lda, local_b, ldb,
-                               beta_k, local_c_partial, ldc, baseline);
+                               beta_k, local_c_partial, ldc, implementation);
 
                     uint32_t end_cycle = snrt_mcycle();
                 }

--- a/sw/blas/gemm/src/gemm_fp16.h
+++ b/sw/blas/gemm/src/gemm_fp16.h
@@ -9,8 +9,7 @@
 
 void gemm_fp16_baseline(uint32_t M, uint32_t N, uint32_t K, __fp16* A,
                         uint32_t ldA, __fp16* B, uint32_t ldB, __fp16* C,
-                        uint32_t ldC, const uint32_t* BETA,
-                        uint32_t setup_SSR) {
+                        uint32_t ldC, const uint32_t* BETA) {
     for (uint32_t m = 0; m < M; m++) {
         uint32_t n = 0;
         for (; n < N; n++) {

--- a/sw/blas/gemm/src/gemm_fp8.h
+++ b/sw/blas/gemm/src/gemm_fp8.h
@@ -34,7 +34,7 @@ void gemm_fp8_naive(uint32_t M, uint32_t N, uint32_t K, char* A, uint32_t ldA,
 
 void gemm_fp8_baseline(uint32_t M, uint32_t N, uint32_t K, char* A,
                        uint32_t ldA, char* B, uint32_t ldB, char* C,
-                       uint32_t ldC, float BETA, uint32_t setup_SSR) {
+                       uint32_t ldC, float BETA) {
     for (uint32_t m = 0; m < M; m++) {
         uint32_t n = 0;
         for (; n < N; n++) {

--- a/sw/blas/gemm/src/main.c
+++ b/sw/blas/gemm/src/main.c
@@ -17,7 +17,7 @@
 int main() {
     int retcode = gemm(dtype_size, expand, 1, parallelize_m, parallelize_k,
                        m_tiles, n_tiles, k_tiles, 1, 1, 1, TA, TB, M, N, K, 1,
-                       a, b, BETA, c, baseline);
+                       a, b, BETA, c, implementation);
 
     snrt_cluster_hw_barrier();
 

--- a/target/snitch_cluster/sw/apps/blas/gemm/test/cfg/fp16-ex-opt.json
+++ b/target/snitch_cluster/sw/apps/blas/gemm/test/cfg/fp16-ex-opt.json
@@ -16,5 +16,5 @@
     k_tiles: 1,
     parallelize_m: 0,
     parallelize_k: 0,
-    baseline: false
+    implementation: "OPT_EX"
 }

--- a/target/snitch_cluster/sw/apps/blas/gemm/test/cfg/fp16-opt.json
+++ b/target/snitch_cluster/sw/apps/blas/gemm/test/cfg/fp16-opt.json
@@ -16,5 +16,5 @@
     k_tiles: 1,
     parallelize_m: 0,
     parallelize_k: 0,
-    baseline: false
+    implementation: "OPT"
 }

--- a/target/snitch_cluster/sw/apps/blas/gemm/test/cfg/fp32-base.json
+++ b/target/snitch_cluster/sw/apps/blas/gemm/test/cfg/fp32-base.json
@@ -16,5 +16,5 @@
     k_tiles: 1,
     parallelize_m: 0,
     parallelize_k: 0,
-    baseline: true
+    implementation: "NAIVE"
 }

--- a/target/snitch_cluster/sw/apps/blas/gemm/test/cfg/fp32-opt.json
+++ b/target/snitch_cluster/sw/apps/blas/gemm/test/cfg/fp32-opt.json
@@ -16,5 +16,5 @@
     k_tiles: 1,
     parallelize_m: 0,
     parallelize_k: 0,
-    baseline: false
+    implementation: "OPT"
 }

--- a/target/snitch_cluster/sw/apps/blas/gemm/test/cfg/fp64-base-tb.json
+++ b/target/snitch_cluster/sw/apps/blas/gemm/test/cfg/fp64-base-tb.json
@@ -16,5 +16,5 @@
     k_tiles: 1,
     parallelize_m: 0,
     parallelize_k: 0,
-    baseline: true
+    implementation: "NAIVE"
 }

--- a/target/snitch_cluster/sw/apps/blas/gemm/test/cfg/fp64-base-tiled.json
+++ b/target/snitch_cluster/sw/apps/blas/gemm/test/cfg/fp64-base-tiled.json
@@ -16,5 +16,5 @@
     k_tiles: 2,
     parallelize_m: 0,
     parallelize_k: 0,
-    baseline: true
+    implementation: "NAIVE"
 }

--- a/target/snitch_cluster/sw/apps/blas/gemm/test/cfg/fp64-base.json
+++ b/target/snitch_cluster/sw/apps/blas/gemm/test/cfg/fp64-base.json
@@ -16,5 +16,5 @@
     k_tiles: 1,
     parallelize_m: 0,
     parallelize_k: 0,
-    baseline: true
+    implementation: "NAIVE"
 }

--- a/target/snitch_cluster/sw/apps/blas/gemm/test/cfg/fp64-opt-tb.json
+++ b/target/snitch_cluster/sw/apps/blas/gemm/test/cfg/fp64-opt-tb.json
@@ -16,5 +16,5 @@
     k_tiles: 1,
     parallelize_m: 0,
     parallelize_k: 0,
-    baseline: false
+    implementation: "OPT"
 }

--- a/target/snitch_cluster/sw/apps/blas/gemm/test/cfg/fp64-opt-tiled.json
+++ b/target/snitch_cluster/sw/apps/blas/gemm/test/cfg/fp64-opt-tiled.json
@@ -16,5 +16,5 @@
     k_tiles: 2,
     parallelize_m: 0,
     parallelize_k: 0,
-    baseline: false
+    implementation: "OPT"
 }

--- a/target/snitch_cluster/sw/apps/blas/gemm/test/cfg/fp64-opt.json
+++ b/target/snitch_cluster/sw/apps/blas/gemm/test/cfg/fp64-opt.json
@@ -16,5 +16,5 @@
     k_tiles: 1,
     parallelize_m: 0,
     parallelize_k: 0,
-    baseline: false
+    implementation: "OPT"
 }

--- a/target/snitch_cluster/sw/apps/blas/gemm/test/cfg/fp8-base.json
+++ b/target/snitch_cluster/sw/apps/blas/gemm/test/cfg/fp8-base.json
@@ -16,5 +16,5 @@
     k_tiles: 1,
     parallelize_m: 0,
     parallelize_k: 0,
-    baseline: true
+    implementation: "NAIVE"
 }


### PR DESCRIPTION
The new `implementation_t` let's you now select which kernel variant you want to run. The supported flavors include: 

1. `BASELINE` : Assembly-based baseline kernel (FP32, FP16, FP8)
2. `NAIVE` : Simple for-loops for computing the GEMM (FP64, FP32, FP8)
3. `NAIVE_UNROLLED` : for-loops with loop unrolling (FP32)
4. `OPT` : Optimized kernels leveraging SSRs and FREP (FP64, FP32, FP16)
5. `OPT_EX` : Optimized low-precision kernels with expanding to the next higher precision (FP16, FP8)