### PR TITLE
fused_concat: Support fp8-fp32

### DIFF
--- a/sw/dnn/fused_concat_linear/data/params.json
+++ b/sw/dnn/fused_concat_linear/data/params.json
@@ -8,4 +8,4 @@
     output_shape: [32, 16],
     dtype: "FP64",
     baseline: true
-}
+}    trans_weights: true,

--- a/sw/dnn/fused_concat_linear/data/params.json
+++ b/sw/dnn/fused_concat_linear/data/params.json
@@ -4,8 +4,9 @@
 
 {
     num_inputs: 1,
-    input_shape: [32, 4],
-    output_shape: [32, 16],
-    dtype: "FP64",
-    baseline: true
-}    trans_weights: true,
+    input_shape: [64, 16],
+    output_shape: [64, 16],
+    trans_weights: true,
+    dtype: "FP16",
+    implementation: "BASELINE"
+}

--- a/sw/dnn/fused_concat_linear/scripts/verify.py
+++ b/sw/dnn/fused_concat_linear/scripts/verify.py
@@ -6,7 +6,6 @@
 # Luca Colagrande <colluca@iis.ee.ethz.ch>
 
 import sys
-import torch
 from pathlib import Path
 from datagen import golden_model
 
@@ -46,11 +45,11 @@ class FusedConcatLinearVerifier(Verifier):
     def get_expected_results(self):
         inputs = [self.get_input_from_symbol(f'input_{i}', ctype_from_precision_t(self.prec))
                   for i in range(self.num_inputs)]
-        inputs = [torch.from_numpy(tensor.reshape(self.input_shape)) for tensor in inputs]
+        inputs = [tensor.reshape(self.input_shape) for tensor in inputs]
         weights = self.get_input_from_symbol('weights', ctype_from_precision_t(self.prec))
-        weights = torch.from_numpy(weights.reshape(self.weights_shape))
+        weights = weights.reshape(self.weights_shape)
         output_golden, _ = golden_model(inputs, weights)
-        return output_golden.detach().numpy().flatten()
+        return output_golden.flatten()
 
     def check_results(self, *args):
         return super().check_results(*args, rtol=1E-6)

--- a/sw/dnn/fused_concat_linear/scripts/verify.py
+++ b/sw/dnn/fused_concat_linear/scripts/verify.py
@@ -17,6 +17,7 @@ from data_utils import ctype_from_precision_t  # noqa: E402
 class FusedConcatLinearVerifier(Verifier):
 
     OUTPUT_UIDS = ['linear_output']
+    ERR_THRESHOLD = {8: 1e-6, 4: 1e-6, 2: 1e-2, 1: 1e-4}
 
     def __init__(self):
         super().__init__()
@@ -56,7 +57,7 @@ class FusedConcatLinearVerifier(Verifier):
         return output_golden.flatten()
 
     def check_results(self, *args):
-        return super().check_results(*args, rtol=1E-6)
+        return super().check_results(*args, rtol=self.ERR_THRESHOLD[self.prec])
 
 
 if __name__ == "__main__":

--- a/sw/dnn/fused_concat_linear/scripts/verify.py
+++ b/sw/dnn/fused_concat_linear/scripts/verify.py
@@ -28,6 +28,7 @@ class FusedConcatLinearVerifier(Verifier):
             'out_width': 'I',
             'inputs': 'I',
             'weights': 'I',
+            'trans_weights': 'I',
             'concat_output': 'I',
             'linear_output': 'I',
             'dtype': 'I',
@@ -43,10 +44,13 @@ class FusedConcatLinearVerifier(Verifier):
         return self.get_output_from_symbol('linear_output', ctype_from_precision_t(self.prec))
 
     def get_expected_results(self):
+        trans_weights = self.get_input_from_symbol('trans_weights', 'uint32_t')[0]
         inputs = [self.get_input_from_symbol(f'input_{i}', ctype_from_precision_t(self.prec))
                   for i in range(self.num_inputs)]
         inputs = [tensor.reshape(self.input_shape) for tensor in inputs]
         weights = self.get_input_from_symbol('weights', ctype_from_precision_t(self.prec))
+        if trans_weights:
+            weights = weights.reshape(self.weights_shape).T
         weights = weights.reshape(self.weights_shape)
         output_golden, _ = golden_model(inputs, weights)
         return output_golden.flatten()


### PR DESCRIPTION
Almost all formats are now working:

### FP64
- [x] `NAIVE`
- [x] `OPT`

### FP32
- [x] `NAIVE`
- [x] `BASELINE`
- [x] `OPT`

### FP16
- [x] `BASELINE`
- [x] `OPT_EX`
- [x] `OPT`

### FP8
- [x] `BASELINE`: kind of works, error is not far off. Probably saturation/cancellation
- [x] `OPT`: Same