### PR TITLE
sw: Adjust `*_decls` headers for usability in downstream projects

### DIFF
--- a/sw/snRuntime/api/alloc_decls.h
+++ b/sw/snRuntime/api/alloc_decls.h
@@ -2,6 +2,11 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
+#pragma once
+
+#include <stddef.h>
+#include <stdint.h>
+
 typedef struct {
     // Base address from where allocation starts
     uint32_t base;
@@ -11,14 +16,14 @@ typedef struct {
     uint32_t next;
 } snrt_allocator_t;
 
-inline void *snrt_l1_next();
+void *snrt_l1_next();
 
-inline void *snrt_l3_next();
+void *snrt_l3_next();
 
-inline void *snrt_l1alloc(size_t size);
+void *snrt_l1alloc(size_t size);
 
-inline void snrt_l1_update_next(void *next);
+void snrt_l1_update_next(void *next);
 
-inline void *snrt_l3alloc(size_t size);
+void *snrt_l3alloc(size_t size);
 
-inline void snrt_alloc_init();
+void snrt_alloc_init();

--- a/sw/snRuntime/api/alloc_decls.h
+++ b/sw/snRuntime/api/alloc_decls.h
@@ -16,14 +16,14 @@ typedef struct {
     uint32_t next;
 } snrt_allocator_t;
 
-void *snrt_l1_next();
+inline void *snrt_l1_next();
 
-void *snrt_l3_next();
+inline void *snrt_l3_next();
 
-void *snrt_l1alloc(size_t size);
+inline void *snrt_l1alloc(size_t size);
 
-void snrt_l1_update_next(void *next);
+inline void snrt_l1_update_next(void *next);
 
-void *snrt_l3alloc(size_t size);
+inline void *snrt_l3alloc(size_t size);
 
-void snrt_alloc_init();
+inline void snrt_alloc_init();

--- a/sw/snRuntime/api/cls_decls.h
+++ b/sw/snRuntime/api/cls_decls.h
@@ -13,4 +13,4 @@ typedef struct {
     snrt_allocator_t l1_allocator;
 } cls_t;
 
-cls_t* cls();
+inline cls_t* cls();

--- a/sw/snRuntime/api/cls_decls.h
+++ b/sw/snRuntime/api/cls_decls.h
@@ -2,9 +2,15 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
+#pragma once
+
+#include <stdint.h>
+
+#include "alloc_decls.h"
+
 typedef struct {
     uint32_t hw_barrier;
     snrt_allocator_t l1_allocator;
 } cls_t;
 
-inline cls_t* cls();
+cls_t* cls();

--- a/sw/snRuntime/api/cluster_interrupt_decls.h
+++ b/sw/snRuntime/api/cluster_interrupt_decls.h
@@ -6,12 +6,12 @@
 
 #include <stdint.h>
 
-void snrt_int_cluster_set(uint32_t mask);
+inline void snrt_int_cluster_set(uint32_t mask);
 
-void snrt_int_cluster_clr(uint32_t mask);
+inline void snrt_int_cluster_clr(uint32_t mask);
 
-void snrt_int_clr_mcip_unsafe();
+inline void snrt_int_clr_mcip_unsafe();
 
-void snrt_int_clr_mcip();
+inline void snrt_int_clr_mcip();
 
-void snrt_int_set_mcip();
+inline void snrt_int_set_mcip();

--- a/sw/snRuntime/api/cluster_interrupt_decls.h
+++ b/sw/snRuntime/api/cluster_interrupt_decls.h
@@ -2,12 +2,16 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-inline void snrt_int_cluster_set(uint32_t mask);
+#pragma once
 
-inline void snrt_int_cluster_clr(uint32_t mask);
+#include <stdint.h>
 
-inline void snrt_int_clr_mcip_unsafe();
+void snrt_int_cluster_set(uint32_t mask);
 
-inline void snrt_int_clr_mcip();
+void snrt_int_cluster_clr(uint32_t mask);
 
-inline void snrt_int_set_mcip();
+void snrt_int_clr_mcip_unsafe();
+
+void snrt_int_clr_mcip();
+
+void snrt_int_set_mcip();

--- a/sw/snRuntime/api/global_interrupt_decls.h
+++ b/sw/snRuntime/api/global_interrupt_decls.h
@@ -2,8 +2,12 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-inline void snrt_int_sw_clear(uint32_t hartid);
+#pragma once
 
-inline void snrt_int_sw_set(uint32_t hartid);
+#include <stdint.h>
 
-inline uint32_t snrt_int_sw_get(uint32_t hartid);
+void snrt_int_sw_clear(uint32_t hartid);
+
+void snrt_int_sw_set(uint32_t hartid);
+
+uint32_t snrt_int_sw_get(uint32_t hartid);

--- a/sw/snRuntime/api/global_interrupt_decls.h
+++ b/sw/snRuntime/api/global_interrupt_decls.h
@@ -6,8 +6,8 @@
 
 #include <stdint.h>
 
-void snrt_int_sw_clear(uint32_t hartid);
+inline void snrt_int_sw_clear(uint32_t hartid);
 
-void snrt_int_sw_set(uint32_t hartid);
+inline void snrt_int_sw_set(uint32_t hartid);
 
-uint32_t snrt_int_sw_get(uint32_t hartid);
+inline uint32_t snrt_int_sw_get(uint32_t hartid);

--- a/sw/snRuntime/api/memory_decls.h
+++ b/sw/snRuntime/api/memory_decls.h
@@ -2,16 +2,20 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-inline uint32_t __attribute__((const)) snrt_l1_start_addr();
+#pragma once
 
-inline uint32_t __attribute__((const)) snrt_l1_end_addr();
+#include <stdint.h>
 
-inline volatile uint32_t* __attribute__((const)) snrt_clint_mutex_ptr();
+uint32_t __attribute__((const)) snrt_l1_start_addr();
 
-inline volatile uint32_t* __attribute__((const)) snrt_clint_msip_ptr();
+uint32_t __attribute__((const)) snrt_l1_end_addr();
 
-inline volatile uint32_t* __attribute__((const)) snrt_cluster_clint_set_ptr();
+volatile uint32_t* __attribute__((const)) snrt_clint_mutex_ptr();
 
-inline volatile uint32_t* __attribute__((const)) snrt_cluster_clint_clr_ptr();
+volatile uint32_t* __attribute__((const)) snrt_clint_msip_ptr();
 
-inline uint32_t __attribute__((const)) snrt_cluster_hw_barrier_addr();
+volatile uint32_t* __attribute__((const)) snrt_cluster_clint_set_ptr();
+
+volatile uint32_t* __attribute__((const)) snrt_cluster_clint_clr_ptr();
+
+uint32_t __attribute__((const)) snrt_cluster_hw_barrier_addr();

--- a/sw/snRuntime/api/memory_decls.h
+++ b/sw/snRuntime/api/memory_decls.h
@@ -6,16 +6,16 @@
 
 #include <stdint.h>
 
-uint32_t __attribute__((const)) snrt_l1_start_addr();
+inline uint32_t __attribute__((const)) snrt_l1_start_addr();
 
-uint32_t __attribute__((const)) snrt_l1_end_addr();
+inline uint32_t __attribute__((const)) snrt_l1_end_addr();
 
-volatile uint32_t* __attribute__((const)) snrt_clint_mutex_ptr();
+inline volatile uint32_t* __attribute__((const)) snrt_clint_mutex_ptr();
 
-volatile uint32_t* __attribute__((const)) snrt_clint_msip_ptr();
+inline volatile uint32_t* __attribute__((const)) snrt_clint_msip_ptr();
 
-volatile uint32_t* __attribute__((const)) snrt_cluster_clint_set_ptr();
+inline volatile uint32_t* __attribute__((const)) snrt_cluster_clint_set_ptr();
 
-volatile uint32_t* __attribute__((const)) snrt_cluster_clint_clr_ptr();
+inline volatile uint32_t* __attribute__((const)) snrt_cluster_clint_clr_ptr();
 
-uint32_t __attribute__((const)) snrt_cluster_hw_barrier_addr();
+inline uint32_t __attribute__((const)) snrt_cluster_hw_barrier_addr();

--- a/sw/snRuntime/api/omp/eu_decls.h
+++ b/sw/snRuntime/api/omp/eu_decls.h
@@ -47,7 +47,8 @@ void eu_event_loop(uint32_t cluster_core_idx);
  * @param argc number of elements in data
  * @param nthreads number of threads that have to execute this event
  */
-int eu_dispatch_push(void (*fn)(void *, uint32_t), uint32_t argc, void *data, uint32_t nthreads);
+int eu_dispatch_push(void (*fn)(void *, uint32_t), uint32_t argc, void *data,
+                     uint32_t nthreads);
 
 /**
  * @brief wait for all workers to idle

--- a/sw/snRuntime/api/omp/eu_decls.h
+++ b/sw/snRuntime/api/omp/eu_decls.h
@@ -2,6 +2,10 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
+#pragma once
+
+#include <stdint.h>
+
 typedef struct {
     uint32_t workers_in_loop;
     uint32_t exit_flag;
@@ -19,20 +23,20 @@ typedef struct {
 /**
  * @brief Initialize the event unit
  */
-inline void eu_init(void);
+void eu_init(void);
 
 /**
  * @brief send all workers in loop to exit()
  * @param core_idx cluster-local core index
  */
-inline void eu_exit(uint32_t core_idx);
+void eu_exit(uint32_t core_idx);
 
 /**
  * @brief Enter the event unit loop, never exits
  *
  * @param cluster_core_idx cluster-local core index
  */
-inline void eu_event_loop(uint32_t cluster_core_idx);
+void eu_event_loop(uint32_t cluster_core_idx);
 
 /**
  * @brief Set function to execute by `nthreads` number of threads
@@ -43,17 +47,16 @@ inline void eu_event_loop(uint32_t cluster_core_idx);
  * @param argc number of elements in data
  * @param nthreads number of threads that have to execute this event
  */
-inline int eu_dispatch_push(void (*fn)(void *, uint32_t), uint32_t argc,
-                            void *data, uint32_t nthreads);
+int eu_dispatch_push(void (*fn)(void *, uint32_t), uint32_t argc, void *data, uint32_t nthreads);
 
 /**
  * @brief wait for all workers to idle
  * @param core_idx cluster-local core index
  */
-inline void eu_run_empty(uint32_t core_idx);
+void eu_run_empty(uint32_t core_idx);
 
 /**
  * @brief Debugging info to printf
  * @details
  */
-inline void eu_print_status();
+void eu_print_status();

--- a/sw/snRuntime/api/omp/eu_decls.h
+++ b/sw/snRuntime/api/omp/eu_decls.h
@@ -47,8 +47,8 @@ inline void eu_event_loop(uint32_t cluster_core_idx);
  * @param argc number of elements in data
  * @param nthreads number of threads that have to execute this event
  */
-inline int eu_dispatch_push(void (*fn)(void *, uint32_t), uint32_t argc, void *data,
-                            uint32_t nthreads);
+inline int eu_dispatch_push(void (*fn)(void *, uint32_t), uint32_t argc,
+                            void *data, uint32_t nthreads);
 
 /**
  * @brief wait for all workers to idle

--- a/sw/snRuntime/api/omp/eu_decls.h
+++ b/sw/snRuntime/api/omp/eu_decls.h
@@ -23,20 +23,20 @@ typedef struct {
 /**
  * @brief Initialize the event unit
  */
-void eu_init(void);
+inline void eu_init(void);
 
 /**
  * @brief send all workers in loop to exit()
  * @param core_idx cluster-local core index
  */
-void eu_exit(uint32_t core_idx);
+inline void eu_exit(uint32_t core_idx);
 
 /**
  * @brief Enter the event unit loop, never exits
  *
  * @param cluster_core_idx cluster-local core index
  */
-void eu_event_loop(uint32_t cluster_core_idx);
+inline void eu_event_loop(uint32_t cluster_core_idx);
 
 /**
  * @brief Set function to execute by `nthreads` number of threads
@@ -47,17 +47,16 @@ void eu_event_loop(uint32_t cluster_core_idx);
  * @param argc number of elements in data
  * @param nthreads number of threads that have to execute this event
  */
-int eu_dispatch_push(void (*fn)(void *, uint32_t), uint32_t argc, void *data,
-                     uint32_t nthreads);
+inline int eu_dispatch_push(void (*fn)(void *, uint32_t), uint32_t argc, void *data, uint32_t nthreads);
 
 /**
  * @brief wait for all workers to idle
  * @param core_idx cluster-local core index
  */
-void eu_run_empty(uint32_t core_idx);
+inline void eu_run_empty(uint32_t core_idx);
 
 /**
  * @brief Debugging info to printf
  * @details
  */
-void eu_print_status();
+inline void eu_print_status();

--- a/sw/snRuntime/api/omp/eu_decls.h
+++ b/sw/snRuntime/api/omp/eu_decls.h
@@ -47,7 +47,8 @@ inline void eu_event_loop(uint32_t cluster_core_idx);
  * @param argc number of elements in data
  * @param nthreads number of threads that have to execute this event
  */
-inline int eu_dispatch_push(void (*fn)(void *, uint32_t), uint32_t argc, void *data, uint32_t nthreads);
+inline int eu_dispatch_push(void (*fn)(void *, uint32_t), uint32_t argc, void *data,
+                            uint32_t nthreads);
 
 /**
  * @brief wait for all workers to idle

--- a/sw/snRuntime/api/riscv_decls.h
+++ b/sw/snRuntime/api/riscv_decls.h
@@ -2,16 +2,18 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-#include "../../deps/riscv-opcodes/encoding.h"
+#pragma once
 
-static inline void snrt_wfi();
+#include <stdint.h>
 
-static inline uint32_t snrt_mcycle();
+void snrt_wfi();
 
-inline void snrt_interrupt_enable(uint32_t irq);
+uint32_t snrt_mcycle();
 
-inline void snrt_interrupt_disable(uint32_t irq);
+void snrt_interrupt_enable(uint32_t irq);
 
-inline void snrt_interrupt_global_enable(void);
+void snrt_interrupt_disable(uint32_t irq);
 
-inline void snrt_interrupt_global_disable(void);
+void snrt_interrupt_global_enable(void);
+
+void snrt_interrupt_global_disable(void);

--- a/sw/snRuntime/api/riscv_decls.h
+++ b/sw/snRuntime/api/riscv_decls.h
@@ -6,14 +6,14 @@
 
 #include <stdint.h>
 
-void snrt_wfi();
+static inline void snrt_wfi();
 
-uint32_t snrt_mcycle();
+static inline uint32_t snrt_mcycle();
 
-void snrt_interrupt_enable(uint32_t irq);
+inline void snrt_interrupt_enable(uint32_t irq);
 
-void snrt_interrupt_disable(uint32_t irq);
+inline void snrt_interrupt_disable(uint32_t irq);
 
-void snrt_interrupt_global_enable(void);
+inline void snrt_interrupt_global_enable(void);
 
-void snrt_interrupt_global_disable(void);
+inline void snrt_interrupt_global_disable(void);

--- a/sw/snRuntime/api/start_decls.h
+++ b/sw/snRuntime/api/start_decls.h
@@ -2,4 +2,6 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-static inline void snrt_exit(int exit_code);
+#pragma once
+
+void snrt_exit(int exit_code);

--- a/sw/snRuntime/api/start_decls.h
+++ b/sw/snRuntime/api/start_decls.h
@@ -4,4 +4,4 @@
 
 #pragma once
 
-void snrt_exit(int exit_code);
+static inline void snrt_exit(int exit_code);

--- a/sw/snRuntime/api/sync_decls.h
+++ b/sw/snRuntime/api/sync_decls.h
@@ -2,6 +2,10 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
+#pragma once
+
+#include <stdint.h>
+
 typedef struct {
     uint32_t volatile cnt;
     uint32_t volatile iteration;
@@ -11,14 +15,14 @@ extern volatile uint32_t _snrt_mutex;
 extern volatile snrt_barrier_t _snrt_barrier;
 extern volatile uint32_t _reduction_result;
 
-inline volatile uint32_t *snrt_mutex();
+volatile uint32_t *snrt_mutex();
 
-inline void snrt_mutex_acquire(volatile uint32_t *pmtx);
+void snrt_mutex_acquire(volatile uint32_t *pmtx);
 
-inline void snrt_mutex_ttas_acquire(volatile uint32_t *pmtx);
+void snrt_mutex_ttas_acquire(volatile uint32_t *pmtx);
 
-inline void snrt_mutex_release(volatile uint32_t *pmtx);
+void snrt_mutex_release(volatile uint32_t *pmtx);
 
-inline void snrt_cluster_hw_barrier();
+void snrt_cluster_hw_barrier();
 
-inline void snrt_global_barrier();
+void snrt_global_barrier();

--- a/sw/snRuntime/api/sync_decls.h
+++ b/sw/snRuntime/api/sync_decls.h
@@ -15,14 +15,14 @@ extern volatile uint32_t _snrt_mutex;
 extern volatile snrt_barrier_t _snrt_barrier;
 extern volatile uint32_t _reduction_result;
 
-volatile uint32_t *snrt_mutex();
+inline volatile uint32_t *snrt_mutex();
 
-void snrt_mutex_acquire(volatile uint32_t *pmtx);
+inline void snrt_mutex_acquire(volatile uint32_t *pmtx);
 
-void snrt_mutex_ttas_acquire(volatile uint32_t *pmtx);
+inline void snrt_mutex_ttas_acquire(volatile uint32_t *pmtx);
 
-void snrt_mutex_release(volatile uint32_t *pmtx);
+inline void snrt_mutex_release(volatile uint32_t *pmtx);
 
-void snrt_cluster_hw_barrier();
+inline void snrt_cluster_hw_barrier();
 
-void snrt_global_barrier();
+inline void snrt_global_barrier();

--- a/sw/snRuntime/api/team_decls.h
+++ b/sw/snRuntime/api/team_decls.h
@@ -6,15 +6,15 @@
 
 #include <stdint.h>
 
-uint32_t __attribute__((const)) snrt_hartid();
-uint32_t __attribute__((const)) snrt_cluster_num();
-uint32_t __attribute__((const)) snrt_cluster_core_num();
-uint32_t __attribute__((const)) snrt_global_core_base_hartid();
-uint32_t __attribute__((const)) snrt_global_core_num();
-uint32_t __attribute__((const)) snrt_global_core_idx();
-uint32_t __attribute__((const)) snrt_cluster_idx();
-uint32_t __attribute__((const)) snrt_cluster_core_idx();
-uint32_t __attribute__((const)) snrt_cluster_dm_core_num();
-uint32_t __attribute__((const)) snrt_cluster_compute_core_num();
-int __attribute__((const)) snrt_is_compute_core();
-int __attribute__((const)) snrt_is_dm_core();
+inline uint32_t __attribute__((const)) snrt_hartid();
+inline uint32_t __attribute__((const)) snrt_cluster_num();
+inline uint32_t __attribute__((const)) snrt_cluster_core_num();
+inline uint32_t __attribute__((const)) snrt_global_core_base_hartid();
+inline uint32_t __attribute__((const)) snrt_global_core_num();
+inline uint32_t __attribute__((const)) snrt_global_core_idx();
+inline uint32_t __attribute__((const)) snrt_cluster_idx();
+inline uint32_t __attribute__((const)) snrt_cluster_core_idx();
+inline uint32_t __attribute__((const)) snrt_cluster_dm_core_num();
+inline uint32_t __attribute__((const)) snrt_cluster_compute_core_num();
+inline int __attribute__((const)) snrt_is_compute_core();
+inline int __attribute__((const)) snrt_is_dm_core();

--- a/sw/snRuntime/api/team_decls.h
+++ b/sw/snRuntime/api/team_decls.h
@@ -2,15 +2,19 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-inline uint32_t __attribute__((const)) snrt_hartid();
-inline uint32_t __attribute__((const)) snrt_cluster_num();
-inline uint32_t __attribute__((const)) snrt_cluster_core_num();
-inline uint32_t __attribute__((const)) snrt_global_core_base_hartid();
-inline uint32_t __attribute__((const)) snrt_global_core_num();
-inline uint32_t __attribute__((const)) snrt_global_core_idx();
-inline uint32_t __attribute__((const)) snrt_cluster_idx();
-inline uint32_t __attribute__((const)) snrt_cluster_core_idx();
-inline uint32_t __attribute__((const)) snrt_cluster_dm_core_num();
-inline uint32_t __attribute__((const)) snrt_cluster_compute_core_num();
-inline int __attribute__((const)) snrt_is_compute_core();
-inline int __attribute__((const)) snrt_is_dm_core();
+#pragma once
+
+#include <stdint.h>
+
+uint32_t __attribute__((const)) snrt_hartid();
+uint32_t __attribute__((const)) snrt_cluster_num();
+uint32_t __attribute__((const)) snrt_cluster_core_num();
+uint32_t __attribute__((const)) snrt_global_core_base_hartid();
+uint32_t __attribute__((const)) snrt_global_core_num();
+uint32_t __attribute__((const)) snrt_global_core_idx();
+uint32_t __attribute__((const)) snrt_cluster_idx();
+uint32_t __attribute__((const)) snrt_cluster_core_idx();
+uint32_t __attribute__((const)) snrt_cluster_dm_core_num();
+uint32_t __attribute__((const)) snrt_cluster_compute_core_num();
+int __attribute__((const)) snrt_is_compute_core();
+int __attribute__((const)) snrt_is_dm_core();

--- a/sw/snRuntime/src/alloc.h
+++ b/sw/snRuntime/src/alloc.h
@@ -2,6 +2,8 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
+#pragma once
+
 #define ALIGN_UP(addr, size) (((addr) + (size)-1) & ~((size)-1))
 #define ALIGN_DOWN(addr, size) ((addr) & ~((size)-1))
 

--- a/sw/snRuntime/src/cls.h
+++ b/sw/snRuntime/src/cls.h
@@ -2,6 +2,8 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
+#pragma once
+
 extern __thread cls_t* _cls_ptr;
 
 inline cls_t* cls() { return _cls_ptr; }

--- a/sw/snRuntime/src/cluster_interrupts.h
+++ b/sw/snRuntime/src/cluster_interrupts.h
@@ -2,6 +2,8 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
+#pragma once
+
 #include "../../deps/riscv-opcodes/encoding.h"
 
 /**

--- a/sw/snRuntime/src/dma.h
+++ b/sw/snRuntime/src/dma.h
@@ -2,6 +2,8 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
+#pragma once
+
 /// A DMA transfer identifier.
 typedef uint32_t snrt_dma_txid_t;
 

--- a/sw/snRuntime/src/dump.h
+++ b/sw/snRuntime/src/dump.h
@@ -17,6 +17,8 @@
 // will print the given value via the 8th register. Alternatively, the
 // `write_csr(reg, val)` macro can be used directly.
 
+#pragma once
+
 #define NAMED_DUMP(type, name, reg)                                           \
     static __attribute__((always_inline)) inline void dump_##name(type val) { \
         asm volatile("csrw " #reg ", %0" ::"rK"(val));                        \

--- a/sw/snRuntime/src/global_interrupts.h
+++ b/sw/snRuntime/src/global_interrupts.h
@@ -2,6 +2,8 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
+#pragma once
+
 /**
  * @brief Clear SW interrupt in CLINT
  * @details

--- a/sw/snRuntime/src/perf_cnt.h
+++ b/sw/snRuntime/src/perf_cnt.h
@@ -2,6 +2,8 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
+#pragma once
+
 /// Different perf counters
 // Must match with `snitch_cluster_peripheral`
 enum snrt_perf_cnt {

--- a/sw/snRuntime/src/printf.h
+++ b/sw/snRuntime/src/printf.h
@@ -2,6 +2,8 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
+#pragma once
+
 // Use snrt_putchar for printf
 #define _putchar snrt_putchar
 

--- a/sw/snRuntime/src/riscv.c
+++ b/sw/snRuntime/src/riscv.c
@@ -6,9 +6,9 @@
 
 #include "riscv.h"
 
-extern inline void snrt_wfi();
+extern void snrt_wfi();
 
-extern inline void snrt_nop();
+extern void snrt_nop();
 
 extern uint32_t snrt_mcycle();
 

--- a/sw/snRuntime/src/riscv.c
+++ b/sw/snRuntime/src/riscv.c
@@ -1,0 +1,18 @@
+
+#include "riscv_decls.h"
+
+#include "riscv.h"
+
+extern inline void snrt_wfi();
+
+extern inline void snrt_nop();
+
+extern uint32_t snrt_mcycle();
+
+extern void snrt_interrupt_enable(uint32_t irq);
+
+extern void snrt_interrupt_disable(uint32_t irq);
+
+extern void snrt_interrupt_global_enable(void);
+
+extern void snrt_interrupt_global_disable(void);

--- a/sw/snRuntime/src/riscv.c
+++ b/sw/snRuntime/src/riscv.c
@@ -1,3 +1,6 @@
+// Copyright 2023 ETH Zurich and University of Bologna.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
 
 #include "riscv_decls.h"
 

--- a/sw/snRuntime/src/riscv.h
+++ b/sw/snRuntime/src/riscv.h
@@ -4,6 +4,8 @@
 
 #include "riscv_decls.h"
 
+#pragma once
+
 #include "../../deps/riscv-opcodes/encoding.h"
 
 /**

--- a/sw/snRuntime/src/riscv.h
+++ b/sw/snRuntime/src/riscv.h
@@ -4,15 +4,17 @@
 
 #include "riscv_decls.h"
 
+#include "../../deps/riscv-opcodes/encoding.h"
+
 /**
  * @brief Put the hart into wait for interrupt state
  *
  */
-static inline void snrt_wfi() { asm volatile("wfi"); }
+inline void snrt_wfi() { asm volatile("wfi"); }
 
-static inline void snrt_nop() { asm volatile("nop" : : :); }
+inline void snrt_nop() { asm volatile("nop" : : :); }
 
-static inline uint32_t snrt_mcycle() {
+inline uint32_t snrt_mcycle() {
     uint32_t register r;
     asm volatile("csrr %0, mcycle" : "=r"(r) : : "memory");
     return r;

--- a/sw/snRuntime/src/ssr.h
+++ b/sw/snRuntime/src/ssr.h
@@ -2,6 +2,8 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
+#pragma once
+
 /// Synchronize the integer and float pipelines.
 inline void snrt_fpu_fence() {
     unsigned tmp;

--- a/sw/snRuntime/src/start.c
+++ b/sw/snRuntime/src/start.c
@@ -103,7 +103,7 @@ static inline void snrt_exit_default(int exit_code) {
         *(snrt_exit_code_destination()) = (exit_code << 1) | 1;
 }
 #ifndef SNRT_CRT0_ALTERNATE_EXIT
-extern inline void snrt_exit(int exit_code) { snrt_exit_default(exit_code); }
+static inline void snrt_exit(int exit_code) { snrt_exit_default(exit_code); }
 #endif
 #endif
 

--- a/sw/snRuntime/src/start.c
+++ b/sw/snRuntime/src/start.c
@@ -103,7 +103,7 @@ static inline void snrt_exit_default(int exit_code) {
         *(snrt_exit_code_destination()) = (exit_code << 1) | 1;
 }
 #ifndef SNRT_CRT0_ALTERNATE_EXIT
-static inline void snrt_exit(int exit_code) { snrt_exit_default(exit_code); }
+extern inline void snrt_exit(int exit_code) { snrt_exit_default(exit_code); }
 #endif
 #endif
 

--- a/sw/snRuntime/src/sync.h
+++ b/sw/snRuntime/src/sync.h
@@ -5,6 +5,8 @@
 // Luca Colagrande <colluca@iis.ee.ethz.ch>
 // Viviane Potocnik <vivianep@iis.ee.ethz.ch>
 
+#pragma once
+
 #include <math.h>
 
 //================================================================================

--- a/sw/snRuntime/src/team.h
+++ b/sw/snRuntime/src/team.h
@@ -2,6 +2,8 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
+#pragma once
+
 inline uint32_t __attribute__((const)) snrt_hartid() {
     uint32_t hartid;
     asm("csrr %0, mhartid" : "=r"(hartid));

--- a/target/snitch_cluster/sw/runtime/banshee/src/snrt.c
+++ b/target/snitch_cluster/sw/runtime/banshee/src/snrt.c
@@ -14,6 +14,7 @@
 #include "omp.c"
 #include "printf.c"
 #include "putchar.c"
+#include "riscv.c"
 #include "snitch_cluster_start.c"
 #include "sync.c"
 #include "team.c"

--- a/target/snitch_cluster/sw/runtime/rtl/src/snrt.c
+++ b/target/snitch_cluster/sw/runtime/rtl/src/snrt.c
@@ -14,6 +14,7 @@
 #include "omp.c"
 #include "printf.c"
 #include "putchar.c"
+#include "riscv.c"
 #include "snitch_cluster_start.c"
 #include "sync.c"
 #include "team.c"


### PR DESCRIPTION
Downstream projects wishing to use the snitch runtime via its `*_decls` headers have so far run into a few issues:
* Not all headers correctly include the C standard headers of entities they depend on
* There were no header guards or similar present, making multiple includes an error in many cases

This PR fixes these issues by:
* `#include`ing required headers
* Adding `#pragma once` to all headers

As a further drive-by, the riscv_decls.h header was fixed to be usable without linking errors the same way as other files