### PR TITLE
sw: Add missing `extern` declarations

### DIFF
--- a/sw/snRuntime/src/alloc.c
+++ b/sw/snRuntime/src/alloc.c
@@ -4,7 +4,7 @@
 
 snrt_allocator_t l3_allocator;
 
-extern volatile uint32_t* snrt_zero_memory_ptr();
+extern volatile uint32_t *snrt_zero_memory_ptr();
 
 extern void *snrt_l1_next();
 extern void *snrt_l3_next();

--- a/sw/snRuntime/src/alloc.c
+++ b/sw/snRuntime/src/alloc.c
@@ -4,11 +4,19 @@
 
 snrt_allocator_t l3_allocator;
 
+extern volatile uint32_t* snrt_zero_memory_ptr();
+
 extern void *snrt_l1_next();
 extern void *snrt_l3_next();
 
+extern uint32_t snrt_l1_start_addr();
+extern uint32_t snrt_l1_end_addr();
+
 extern void *snrt_l1alloc(size_t size);
 extern void *snrt_l3alloc(size_t size);
+
+extern snrt_allocator_t *snrt_l1_allocator();
+extern snrt_allocator_t *snrt_l3_allocator();
 
 extern void snrt_l1_update_next(void *next);
 

--- a/sw/snRuntime/src/cls.c
+++ b/sw/snRuntime/src/cls.c
@@ -5,3 +5,5 @@
 __thread cls_t* _cls_ptr;
 
 cls_t __attribute__((section(".cbss"))) _cls;
+
+extern cls_t* cls();

--- a/sw/snRuntime/src/sync.c
+++ b/sw/snRuntime/src/sync.c
@@ -30,3 +30,5 @@ extern void snrt_partial_barrier(snrt_barrier_t *barr, uint32_t n);
 
 extern void snrt_global_reduction_dma(double *dst_buffer, double *src_buffer,
                                       size_t len);
+
+extern uint32_t snrt_global_all_to_all_reduction(uint32_t value);


### PR DESCRIPTION
Without these `extern` declarations, the final object file will not contain functions marked `inline` as LLVM discards them prior to code generation.

This has so far not been problematic as these methods usually get inlined. Downstream projects as well as consumers of the `api/` headers may, however, be using different compiler flags or not have inline definitions available within the same translation unit. This would then cause an "undefined reference" linker error in any such project.