### PR TITLE
target: Allow verilator build with musl libc

### DIFF
--- a/target/common/test/tb_bin.cc
+++ b/target/common/test/tb_bin.cc
@@ -2,7 +2,7 @@
 // Solderpad Hardware License, Version 0.51, see LICENSE for details.
 // SPDX-License-Identifier: SHL-0.51
 
-#include <printf.h>
+#include <stdio.h>
 
 #include "sim.hh"
 

--- a/target/common/test/tb_lib.hh
+++ b/target/common/test/tb_lib.hh
@@ -12,7 +12,7 @@ namespace sim {
 
 struct GlobalMemory {
     static constexpr size_t ADDR_SHIFT = 12;
-    static constexpr size_t PAGE_SIZE = (size_t)1 << ADDR_SHIFT;
+    static constexpr size_t SIZE_OF_PAGE = (size_t)1 << ADDR_SHIFT;
 
     std::unordered_map<uint64_t, std::unique_ptr<uint8_t[]>> pages;
     std::set<uint64_t> touched;
@@ -49,8 +49,8 @@ struct GlobalMemory {
             if (!page) {
                 // std::cout << "[TB] Allocate page " << std::hex << (addr <<
                 // ADDR_SHIFT) << "\n";
-                page = std::make_unique<uint8_t[]>(PAGE_SIZE);
-                std::fill(&page[0], &page[PAGE_SIZE], 0);
+                page = std::make_unique<uint8_t[]>(SIZE_OF_PAGE);
+                std::fill(&page[0], &page[SIZE_OF_PAGE], 0);
             }
             // std::cout << "[TB] Write to page " << std::hex << (addr <<
             // ADDR_SHIFT)
@@ -67,7 +67,7 @@ struct GlobalMemory {
                     if (host) {
                         *host = data[data_idx];
                     } else {
-                        page[i % PAGE_SIZE] = data[data_idx];
+                        page[i % SIZE_OF_PAGE] = data[data_idx];
                         any_changed = true;
                     }
                 }
@@ -101,7 +101,7 @@ struct GlobalMemory {
                     if (page) {
                         // std::cout << "[TB] Read byte " << std::hex << i <<
                         // "\n";
-                        data[data_idx] = page[i % PAGE_SIZE];
+                        data[data_idx] = page[i % SIZE_OF_PAGE];
                     } else {
                         data[data_idx] = 0;
                     }

--- a/target/common/test/verilator_lib.cc
+++ b/target/common/test/verilator_lib.cc
@@ -2,7 +2,7 @@
 // Solderpad Hardware License, Version 0.51, see LICENSE for details.
 // SPDX-License-Identifier: SHL-0.51
 
-#include <printf.h>
+#include <stdio.h>
 
 #include "Vtestharness.h"
 #include "Vtestharness__Dpi.h"


### PR DESCRIPTION
Building the snitch verilator model on distros using musl libc is currently not possible due to some glibc specific assumption and a musl libc peculiarly. More specifically, code was using `#include <printf.h>` instead of `#include <stdio.h>` which is a glibc specific header. Lastly, `PAGE_SIZE` is a macro provided by Linux headers that expands to a number. musl libc unfortunately indirectly includes it via `#include <limit.h>`. Renaming occurrences of `PAGE_SIZE` fixes the name clash.