### PR TITLE
util/sim: Robustify subprocess termination

### DIFF
--- a/util/sim/sim_utils.py
+++ b/util/sim/sim_utils.py
@@ -236,14 +236,38 @@ def dump_report(sims, path=None):
 
 def terminate_processes():
     print('Terminate processes')
+
     # Get PID and PGID of parent process (current Python script)
     ppid = os.getpid()
     pgid = os.getpgid(0)
-    # Kill processes in current process group, except parent process
-    for proc in psutil.process_iter(['pid', 'name']):
+
+    def is_live_subprocess(proc):
         pid = proc.info['pid']
-        if os.getpgid(pid) == pgid and pid != ppid:
-            os.kill(pid, signal.SIGKILL)
+        status = proc.info['status']
+        return os.getpgid(pid) == pgid and pid != ppid and status != psutil.STATUS_ZOMBIE
+
+    def get_living_subprocesses():
+        return [proc for proc in psutil.process_iter(['pid', 'name', 'status'])
+                if is_live_subprocess(proc)]
+
+    # From the moment we list all subprocesses to be killed and the moment
+    # each process is killed, a process may spawn a new subprocess. To be
+    # sure we do not run into such a situation, we have to check that
+    # there are no remaining subprocesses, and loop until this condition
+    # is true. We loop for a maximum of 10 iterations.
+    iterations = 0
+    while get_living_subprocesses() and iterations < 10:
+        living_subprocs = get_living_subprocesses()
+        print(f'{len(living_subprocs)} living subprocesses of {ppid}')
+        print(living_subprocs)
+        [os.kill(proc.info['pid'], signal.SIGKILL) for proc in living_subprocs]
+        iterations += 1
+        time.sleep(1)
+    if iterations == 10:
+        print('TERMINATION ABORTED AFTER 10 ITERATIONS')
+    if get_living_subprocesses():
+        print('THERE ARE STILL LIVING SUBPROCESSES')
+        print(get_living_subprocesses())
 
 
 def get_unique_run_dir(sim, prefix=None):


### PR DESCRIPTION
Addresses a possible race condition for which, from the moment living subprocesses are listed and killed, new subprocesses could be spawned, which would never be killed.

This solution provides a remedy so long as this race condition doesn't occur 10 times in a row. Note that it does not fundamentally solve the problem, but even if subprocesses might still be leaked, the leakage rate should be acceptable.