### PR TITLE
util/sim: Handle `ProcessLookupError` in subprocess termination

### DIFF
--- a/util/sim/sim_utils.py
+++ b/util/sim/sim_utils.py
@@ -258,9 +258,12 @@ def terminate_processes():
     iterations = 0
     while get_living_subprocesses() and iterations < 10:
         living_subprocs = get_living_subprocesses()
-        print(f'{len(living_subprocs)} living subprocesses of {ppid}')
-        print(living_subprocs)
-        [os.kill(proc.info['pid'], signal.SIGKILL) for proc in living_subprocs]
+        print(f'{len(living_subprocs)} living subprocesses of {ppid}\n{living_subprocs}')
+        for proc in living_subprocs:
+            try:
+                os.kill(proc.info['pid'], signal.SIGKILL)
+            except ProcessLookupError:
+                pass
         iterations += 1
         time.sleep(1)
     if iterations == 10:


### PR DESCRIPTION
Killing a process can indirectly cause another process to terminate. Therefore, a previously listed living subprocess may not exist anymore when we attempt to kill it, raising a `ProcessLookupError` exception.

This PR addresses this issue, by handling any `ProcessLookupError` which may arise in this setting, simply ignoring it.