### PR TITLE
target: Add `VLT_NUM_THREADS` to configure threads used by verilator

### DIFF
--- a/target/common/common.mk
+++ b/target/common/common.mk
@@ -44,6 +44,7 @@ EVENTVIS_PY      ?= $(UTIL_DIR)/trace/eventvis.py
 # a two-liner with the OS on the first line, hence the tail -n1
 VERILATOR_ROOT ?= $(dir $(shell $(VERILATOR_SEPP) which verilator | tail -n1))..
 VLT_ROOT       ?= ${VERILATOR_ROOT}
+VLT_NUM_THREADS ?= 1
 
 MATCH_END := '/+incdir+/ s/$$/\/*\/*/'
 MATCH_BGN := 's/+incdir+//g'
@@ -86,7 +87,13 @@ VLT_FLAGS    += -Wno-UNSIGNED
 VLT_FLAGS    += -Wno-UNOPTFLAT
 VLT_FLAGS    += -Wno-fatal
 VLT_FLAGS    += --unroll-count 1024
+ifneq ($(VLT_NUM_THREADS), 1)
+	VLT_FLAGS	 += --threads $(VLT_NUM_THREADS)
+endif
 VLT_CFLAGS   += -std=c++14 -pthread
+ifneq ($(VLT_NUM_THREADS), 1)
+	VLT_CFLAGS	 += -DVL_THREADED=1
+endif
 VLT_CFLAGS   +=-I ${VLT_BUILDDIR} -I $(VLT_ROOT)/include -I $(VLT_ROOT)/include/vltstd -I $(VLT_FESVR)/include -I $(TB_DIR) -I ${MKFILE_DIR}/test
 
 ANNOTATE_FLAGS      ?= -q --keep-time --addr2line=$(ADDR2LINE)

--- a/target/common/common.mk
+++ b/target/common/common.mk
@@ -87,13 +87,11 @@ VLT_FLAGS    += -Wno-UNSIGNED
 VLT_FLAGS    += -Wno-UNOPTFLAT
 VLT_FLAGS    += -Wno-fatal
 VLT_FLAGS    += --unroll-count 1024
-ifneq ($(VLT_NUM_THREADS), 1)
-	VLT_FLAGS	 += --threads $(VLT_NUM_THREADS)
-endif
+VLT_FLAGS	 += --threads $(VLT_NUM_THREADS)
 VLT_CFLAGS   += -std=c++14 -pthread
-ifneq ($(VLT_NUM_THREADS), 1)
-	VLT_CFLAGS	 += -DVL_THREADED=1
-endif
+# Custom test benches including the harness must manually define 'VL_THREADED' if multithreaded.
+# See https://github.com/verilator/verilator/issues/3668#issuecomment-1288989145.
+VLT_CFLAGS	 += -DVL_THREADED
 VLT_CFLAGS   +=-I ${VLT_BUILDDIR} -I $(VLT_ROOT)/include -I $(VLT_ROOT)/include/vltstd -I $(VLT_FESVR)/include -I $(TB_DIR) -I ${MKFILE_DIR}/test
 
 ANNOTATE_FLAGS      ?= -q --keep-time --addr2line=$(ADDR2LINE)

--- a/target/snitch_cluster/Makefile
+++ b/target/snitch_cluster/Makefile
@@ -103,9 +103,7 @@ VLT_COBJ += $(VLT_BUILDDIR)/tb/tb_bin.o
 VLT_COBJ += $(VLT_BUILDDIR)/vlt/verilated.o
 VLT_COBJ += $(VLT_BUILDDIR)/vlt/verilated_dpi.o
 VLT_COBJ += $(VLT_BUILDDIR)/vlt/verilated_vcd_c.o
-ifneq ($(VLT_NUM_THREADS), 1)
-	VLT_COBJ += $(VLT_BUILDDIR)/vlt/verilated_threads.o
-endif
+VLT_COBJ += $(VLT_BUILDDIR)/vlt/verilated_threads.o
 # Bootdata
 VLT_COBJ += $(VLT_BUILDDIR)/generated/bootdata.o
 

--- a/target/snitch_cluster/Makefile
+++ b/target/snitch_cluster/Makefile
@@ -103,6 +103,9 @@ VLT_COBJ += $(VLT_BUILDDIR)/tb/tb_bin.o
 VLT_COBJ += $(VLT_BUILDDIR)/vlt/verilated.o
 VLT_COBJ += $(VLT_BUILDDIR)/vlt/verilated_dpi.o
 VLT_COBJ += $(VLT_BUILDDIR)/vlt/verilated_vcd_c.o
+ifneq ($(VLT_NUM_THREADS), 1)
+	VLT_COBJ += $(VLT_BUILDDIR)/vlt/verilated_threads.o
+endif
 # Bootdata
 VLT_COBJ += $(VLT_BUILDDIR)/generated/bootdata.o
 


### PR DESCRIPTION
Using more threads in the simulation may lead to a speedup in simulation time, especially when the program running in the simulator makes use of multiple cores. This PR therefore adds the `VLT_NUM_THREADS` option to `make` to allow users to set the thread number used in the simulator. For backwards compatibility, and since the number of threads is environment and code dependent, the default value of 1 was kept.