### PR TITLE
sw: Fix `snrt_dma_wait` implementation

### DIFF
--- a/docs/rm/custom_instructions.md
+++ b/docs/rm/custom_instructions.md
@@ -104,7 +104,7 @@ The DMSTATI instruction can be used to implement a blocking wait for the complet
 
         dmcpyi a0, ...
     1:  dmstati t0, 0
-        bltu a0, t0, 1b
+        bltu t0, a0, 1b
 
 Similarly, waiting for the completion of *all* DMA transfers:
 

--- a/sw/snRuntime/src/dma.h
+++ b/sw/snRuntime/src/dma.h
@@ -151,8 +151,7 @@ inline void snrt_dma_wait(snrt_dma_txid_t tid) {
                (    0b000 << 12) | \
                (      (5) <<  7) | \
                (0b0101011 <<  0)   \n"
-        "sub t0, t0, %0 \n"
-        "blez t0, 1b \n" ::"r"(tid)
+        "bltu t0, %0, 1b \n" ::"r"(tid)
         : "t0");
 }
 

--- a/sw/tests/dma_simple.c
+++ b/sw/tests/dma_simple.c
@@ -21,8 +21,8 @@ int main() {
     }
 
     // Copy data to main memory.
-    snrt_dma_start_1d(buffer, buffer_src, sizeof(buffer));
-    snrt_dma_wait_all();
+    snrt_dma_txid_t id = snrt_dma_start_1d(buffer, buffer_src, sizeof(buffer));
+    snrt_dma_wait(id);
 
     // Check that the main memory buffer contains the correct data.
     for (uint32_t i = 0; i < 32; i++) {


### PR DESCRIPTION
The previous implementation of `snrt_dma_wait` was incorrect as it had an infinite loop in the case that `tid` was the last completed transaction. Looking at the documentation, the snippet in custom_instructions.md shows the correct way of implementing the transaction check (get last completed tid and loop if it's less than the one we are waiting for) except it had its register operands swapped. This PR uses that implementation instead, fixes the small bug in the documentation and changes one of the waits in `dma_simple.c` to make sure we don't regress either.