### PR TITLE
container: Fix Banshee installation

### DIFF
--- a/util/container/Dockerfile
+++ b/util/container/Dockerfile
@@ -77,8 +77,8 @@ RUN wget https://github.com/Kitware/CMake/releases/download/v${CMAKE_VERSION}/cm
 ENV PATH "/tools/bin:${PATH}"
 
 # Install `banshee` (needs cmake)
-RUN rustup install 1.63.0
-RUN rustup override set 1.63.0
+RUN rustup install 1.67.0
+RUN rustup override set 1.67.0
 RUN git clone https://github.com/pulp-platform/banshee.git /tmp/banshee --recurse-submodules
 RUN cargo install --path /tmp/banshee
 


### PR DESCRIPTION
Fixes Banshee installation in our Docker container. See https://github.com/pulp-platform/banshee/pull/19 for more info.