### PR TITLE
sw: Runtime Fixes

### DIFF
--- a/sw/snRuntime/base.ld
+++ b/sw/snRuntime/base.ld
@@ -66,7 +66,7 @@ SECTIONS
   .cbss :
   {
     __cbss_start = .;
-    *(.cbss .cbss.*)
+    KEEP(*(.cbss .cbss.*))
     __cbss_end = .;
   } >L3
 

--- a/target/snitch_cluster/sw/runtime/rtl/src/putchar.c
+++ b/target/snitch_cluster/sw/runtime/rtl/src/putchar.c
@@ -51,10 +51,12 @@ void _putchar(char character) {
         buf->hdr.syscall_mem[2] = (uintptr_t)&buf->data;  // buffer
         buf->hdr.syscall_mem[3] = buf->hdr.size;          // length
 
+        snrt_mutex_acquire(snrt_mutex());
         tohost = (uintptr_t)buf->hdr.syscall_mem;
         while (fromhost == 0)
             ;
         fromhost = 0;
+        snrt_mutex_release(snrt_mutex());
 
         buf->hdr.size = 0;
     }

--- a/target/snitch_cluster/sw/runtime/rtl/src/putchar.c
+++ b/target/snitch_cluster/sw/runtime/rtl/src/putchar.c
@@ -25,16 +25,21 @@ void _putchar(char character) {
 extern uintptr_t volatile tohost, fromhost;
 
 // Rudimentary string buffer for putc calls.
-extern uint32_t _edram;
 #define PUTC_BUFFER_LEN (1024 - sizeof(size_t))
-struct putc_buffer_header {
+
+typedef struct {
     size_t size;
     uint64_t syscall_mem[8];
-};
-static volatile struct putc_buffer {
-    struct putc_buffer_header hdr;
+} putc_buffer_header_t;
+
+typedef struct putc_buffer {
+    putc_buffer_header_t hdr;
     char data[PUTC_BUFFER_LEN];
-} *const putc_buffer = (void *)&_edram;
+} putc_buffer_t;
+
+static volatile putc_buffer_t
+    putc_buffer[SNRT_CLUSTER_NUM * SNRT_CLUSTER_CORE_NUM]
+    __attribute__((section(".dram")));
 
 // Provide an implementation for putchar.
 void _putchar(char character) {


### PR DESCRIPTION
This PR introduces two fixes to the Snitch runtime that are required for Deeploy.

The first issue is related to the location of the `snrt_l1_allocator()` which is calculated via the `cls()` function. This function uses the `_cls_ptr` which is placed at the beginning of the `.cbss` section. However, if the `.cbss` section is empty, this location is invalid.

The second fix statically allocated the buffers for multicore compatible `printf()` function. Without this fix, the buffers overlap with the L3 allocator, causing `printf()` call to overwrite the allocation structure.

## Fixed
- Ensure the `.cbss` section is not optimized away.
-  Statically allocate `printf()` buffers