### PR TITLE
util: Disable Banshee simulation traces

### DIFF
--- a/util/sim/Simulation.py
+++ b/util/sim/Simulation.py
@@ -293,4 +293,4 @@ class BansheeSimulation(Simulation):
         """
         super().__init__(**kwargs)
         self.cmd = ['banshee', '--no-opt-llvm', '--no-opt-jit', '--configuration',
-                    str(banshee_cfg), '--trace', str(self.elf)]
+                    str(banshee_cfg), str(self.elf)]


### PR DESCRIPTION
Some spurious behaviour in Banshee caused the simulation traces to take up GBs of space on our internal CI servers, as reported by @Xeratec.

As the Banshee traces are not used in any way, this PR disables trace logging in Banshee, which will anyways hopefully be replaced by GVSoC sometime soon.