### PR TITLE
deps: Track `Bender.lock` file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,6 @@
 
 # Dependency files
 /.bender/
-/Bender.lock
 
 # Modelsim Files
 *.wlf

--- a/Bender.local
+++ b/Bender.local
@@ -4,4 +4,4 @@
 
 overrides:
     # Some of our dependencies have false conflicts with our new AXI version; force our version.
-    axi: {git: https://github.com/pulp-platform/axi.git, version:  0.39.4 }
+    axi: {git: https://github.com/pulp-platform/axi.git, rev:  vcs-fixes }

--- a/Bender.local
+++ b/Bender.local
@@ -1,7 +1,0 @@
-# Copyright 2020 ETH Zurich and University of Bologna.
-# Licensed under the Apache License, Version 2.0, see LICENSE for details.
-# SPDX-License-Identifier: Apache-2.0
-
-overrides:
-    # Some of our dependencies have false conflicts with our new AXI version; force our version.
-    axi: {git: https://github.com/pulp-platform/axi.git, rev:  vcs-fixes }

--- a/Bender.local
+++ b/Bender.local
@@ -4,4 +4,4 @@
 
 overrides:
     # Some of our dependencies have false conflicts with our new AXI version; force our version.
-    axi: {git: https://github.com/pulp-platform/axi.git, version:  0.39.2 }
+    axi: {git: https://github.com/pulp-platform/axi.git, version:  0.39.4 }

--- a/Bender.lock
+++ b/Bender.lock
@@ -1,0 +1,123 @@
+packages:
+  apb:
+    revision: 77ddf073f194d44b9119949d2421be59789e69ae
+    version: 0.2.4
+    source:
+      Git: https://github.com/pulp-platform/apb.git
+    dependencies:
+    - common_cells
+  axi:
+    revision: 41859549968db0147062b6c3cdbe4af00080cc09
+    version: null
+    source:
+      Git: https://github.com/pulp-platform/axi
+    dependencies:
+    - common_cells
+    - common_verification
+    - tech_cells_generic
+  axi_riscv_atomics:
+    revision: 430838a10a9bdf1e381d4fcb33907428f3273420
+    version: 0.6.0
+    source:
+      Git: https://github.com/pulp-platform/axi_riscv_atomics
+    dependencies:
+    - axi
+    - common_cells
+    - common_verification
+  axi_stream:
+    revision: 54891ff40455ca94a37641b9da4604647878cc07
+    version: 0.1.1
+    source:
+      Git: https://github.com/pulp-platform/axi_stream.git
+    dependencies:
+    - common_cells
+  cluster_icache:
+    revision: 0e1fb6751d9684d968ba7fb40836e6118b448ecd
+    version: 0.1.1
+    source:
+      Git: https://github.com/pulp-platform/cluster_icache.git
+    dependencies:
+    - axi
+    - common_cells
+    - scm
+    - tech_cells_generic
+  common_cells:
+    revision: c27bce39ebb2e6bae52f60960814a2afca7bd4cb
+    version: 1.37.0
+    source:
+      Git: https://github.com/pulp-platform/common_cells
+    dependencies:
+    - common_verification
+    - tech_cells_generic
+  common_verification:
+    revision: 9c07fa860593b2caabd9b5681740c25fac04b878
+    version: 0.2.3
+    source:
+      Git: https://github.com/pulp-platform/common_verification.git
+    dependencies: []
+  fpnew:
+    revision: a8e0cba6dd50f357ece73c2c955d96efc3c6c315
+    version: null
+    source:
+      Git: https://github.com/pulp-platform/cvfpu.git
+    dependencies:
+    - common_cells
+    - fpu_div_sqrt_mvp
+  fpu_div_sqrt_mvp:
+    revision: 86e1f558b3c95e91577c41b2fc452c86b04e85ac
+    version: 1.0.4
+    source:
+      Git: https://github.com/pulp-platform/fpu_div_sqrt_mvp.git
+    dependencies:
+    - common_cells
+  idma:
+    revision: c12caf59bb482fe44b27361f6924ad346b2d22fe
+    version: 0.6.3
+    source:
+      Git: https://github.com/pulp-platform/iDMA
+    dependencies:
+    - axi
+    - axi_stream
+    - common_cells
+    - common_verification
+    - obi
+    - register_interface
+  obi:
+    revision: c2141a653c755461ff44f61d12aeb5d99fc8e760
+    version: 0.1.3
+    source:
+      Git: https://github.com/pulp-platform/obi.git
+    dependencies:
+    - common_cells
+    - common_verification
+  register_interface:
+    revision: ae616e5a1ec2b41e72d200e5ab09c65e94aebd3d
+    version: 0.4.4
+    source:
+      Git: https://github.com/pulp-platform/register_interface
+    dependencies:
+    - apb
+    - axi
+    - common_cells
+    - common_verification
+  riscv-dbg:
+    revision: 358f90110220adf7a083f8b65d157e836d706236
+    version: 0.8.1
+    source:
+      Git: https://github.com/pulp-platform/riscv-dbg
+    dependencies:
+    - common_cells
+    - tech_cells_generic
+  scm:
+    revision: 998466d2a3c2d7d572e43d2666d93c4f767d8d60
+    version: 1.1.1
+    source:
+      Git: https://github.com/pulp-platform/scm.git
+    dependencies: []
+  tech_cells_generic:
+    revision: 7968dd6e6180df2c644636bc6d2908a49f2190cf
+    version: 0.2.13
+    source:
+      Git: https://github.com/pulp-platform/tech_cells_generic
+    dependencies:
+    - common_verification

--- a/Bender.yml
+++ b/Bender.yml
@@ -19,7 +19,7 @@ package:
     - Matheus Cavalcante <matheusd@iis.ee.ethz.ch>
 
 dependencies:
-  axi:                { git: https://github.com/pulp-platform/axi,                version:  0.39.2  }
+  axi:                { git: https://github.com/pulp-platform/axi,                version:  0.39.4  }
   axi_riscv_atomics:  { git: https://github.com/pulp-platform/axi_riscv_atomics,  version:  0.6.0   }
   common_cells:       { git: https://github.com/pulp-platform/common_cells,       version:  1.35.0  }
   FPnew:              { git: "https://github.com/pulp-platform/cvfpu.git",        rev:      pulp-v0.1.3 }

--- a/Bender.yml
+++ b/Bender.yml
@@ -19,7 +19,7 @@ package:
     - Matheus Cavalcante <matheusd@iis.ee.ethz.ch>
 
 dependencies:
-  axi:                { git: https://github.com/pulp-platform/axi,                version:  0.39.4  }
+  axi:                { git: https://github.com/pulp-platform/axi,                rev:  vcs-fixes  }
   axi_riscv_atomics:  { git: https://github.com/pulp-platform/axi_riscv_atomics,  version:  0.6.0   }
   common_cells:       { git: https://github.com/pulp-platform/common_cells,       version:  1.35.0  }
   FPnew:              { git: "https://github.com/pulp-platform/cvfpu.git",        rev:      pulp-v0.1.3 }

--- a/hw/snitch_cluster/src/snitch_cc.sv
+++ b/hw/snitch_cluster/src/snitch_cc.sv
@@ -854,7 +854,7 @@ module snitch_cc #(
   // pragma translate_off
   int f;
   string fn;
-  logic [63:0] cycle = 0;
+  logic [63:0] cycle;
   initial begin
     // We need to schedule the assignment into a safe region, otherwise
     // `hart_id_i` won't have a value assigned at the beginning of the first

--- a/target/common/common.mk
+++ b/target/common/common.mk
@@ -124,6 +124,7 @@ VLOGAN_FLAGS := -assert svaext
 VLOGAN_FLAGS += -assert disable_cover
 VLOGAN_FLAGS += -full64
 VLOGAN_FLAGS += -kdb
+VLOGAN_FLAGS += -timescale=1ns/1ps
 VHDLAN_FLAGS := -full64
 VHDLAN_FLAGS += -kdb
 


### PR DESCRIPTION
A new AXI patch release broke the Gitlab-CI, and bender automatically incremented the AXI version since we don't have a `Bender.lock` file tracked that locks the IP versions used. To prevent similar problems in the future and to give users of the snitch cluster a clear set of dependency versions I suggest to track the `Bender.lock` file.

Apart from that, this PR does also:
* Bump the AXI version
* Remove the `Bender.local` file, which is redundant now and is anyway more of a hack.
* Fixes some minor issues for VCS simulation that were somehow triggered only after updating the dependencies.

### TODO:
- [ ] Use new AXI release (`0.39.5`) once it is published