### PR TITLE
Fix axi dependency in Bender

### DIFF
--- a/Bender.yml
+++ b/Bender.yml
@@ -19,7 +19,7 @@ package:
     - Matheus Cavalcante <matheusd@iis.ee.ethz.ch>
 
 dependencies:
-  axi:                { git: https://github.com/pulp-platform/axi,                rev:  vcs-fixes  }
+  axi:                { git: https://github.com/pulp-platform/axi,                rev:  4e54ac6766b160217a83a74d5a23af9bbf59e6ee  }
   axi_riscv_atomics:  { git: https://github.com/pulp-platform/axi_riscv_atomics,  version:  0.6.0   }
   common_cells:       { git: https://github.com/pulp-platform/common_cells,       version:  1.35.0  }
   FPnew:              { git: "https://github.com/pulp-platform/cvfpu.git",        rev:      pulp-v0.1.3 }


### PR DESCRIPTION
The axi **vcs-fixes** branch has been merged into the **master** branch some days ago.
The [Bender file](https://github.com/pulp-platform/snitch_cluster/blob/4f55f01ffa4e99421af1b71b5bbbf867faf692bf/Bender.yml#L22) is still trying to point to that branch.
I change the revision to the last [axi commit](https://github.com/pulp-platform/axi/commit/4e54ac6766b160217a83a74d5a23af9bbf59e6ee).