### PR TITLE
util: Extend simulation and trace utilities

### DIFF
--- a/target/common/common.mk
+++ b/target/common/common.mk
@@ -243,4 +243,4 @@ $(ROI_DUMP): $(JOINT_PERF_DUMP) $(ROI_SPEC) $(ROI_PY)
 	$(ROI_PY) $(JOINT_PERF_DUMP) $(ROI_SPEC) --cfg $(CFG) -o $@
 
 $(VISUAL_TRACE): $(ROI_DUMP) $(VISUALIZE_PY)
-	$(VISUALIZE_PY) $(ROI_DUMP) --traces $(SNITCH_TXT_TRACES) --elf $(BINARY) -o $@
+	$(VISUALIZE_PY) $(ROI_DUMP) --traces $(SNITCH_TXT_TRACES) --elf $(BINARY) --addr2line $(ADDR2LINE) -o $@

--- a/target/common/common.mk
+++ b/target/common/common.mk
@@ -211,6 +211,8 @@ JOINT_PERF_DUMP   = $(LOGS_DIR)/perf.json
 ROI_DUMP          = $(LOGS_DIR)/roi.json
 VISUAL_TRACE      = $(LOGS_DIR)/trace.json
 
+VISUALIZE_PY_FLAGS += --tracevis "$(BINARY) $(SNITCH_TXT_TRACES) --addr2line $(ADDR2LINE) -f snitch"
+
 .PHONY: traces annotate visual-trace clean-traces clean-annotate clean-perf clean-visual-trace
 traces: $(TXT_TRACES)
 annotate: $(ANNOTATED_TRACES)
@@ -243,4 +245,4 @@ $(ROI_DUMP): $(JOINT_PERF_DUMP) $(ROI_SPEC) $(ROI_PY)
 	$(ROI_PY) $(JOINT_PERF_DUMP) $(ROI_SPEC) --cfg $(CFG) -o $@
 
 $(VISUAL_TRACE): $(ROI_DUMP) $(VISUALIZE_PY)
-	$(VISUALIZE_PY) $(ROI_DUMP) --traces $(SNITCH_TXT_TRACES) --elf $(BINARY) --addr2line $(ADDR2LINE) -o $@
+	$(VISUALIZE_PY) $(ROI_DUMP) $(VISUALIZE_PY_FLAGS) -o $@

--- a/util/bench/visualize.py
+++ b/util/bench/visualize.py
@@ -56,6 +56,12 @@ def main():
         nargs='?',
         default='trace.json',
         help='Output JSON file')
+    parser.add_argument(
+        '--addr2line',
+        metavar='<path>',
+        nargs='?',
+        default='addr2line',
+        help='`addr2line` binary to use for parsing')
     args = parser.parse_args()
 
     # TraceViewer events
@@ -100,7 +106,7 @@ def main():
     # from the simulation traces
     if args.traces and args.elf:
         events += tracevis.parse_traces(args.traces, start=0, end=-1, fmt='snitch',
-                                        addr2line='addr2line', use_time=True, pid=1,
+                                        addr2line=args.addr2line, use_time=True, pid=1,
                                         cache=True, elf=args.elf, collapse_call_stack=True)
 
     # Create TraceViewer JSON object

--- a/util/bench/visualize.py
+++ b/util/bench/visualize.py
@@ -41,14 +41,10 @@ def main():
         metavar='<input>',
         help='Input JSON file')
     parser.add_argument(
-        '--traces',
-        metavar='<trace>',
-        nargs='*',
-        help='Simulation traces to process')
-    parser.add_argument(
-        '--elf',
-        nargs='?',
-        help='ELF from which the traces were generated')
+        '--tracevis',
+        action='append',
+        default=[],
+        help='Argument string to pass down to tracevis, to generate additional events.')
     parser.add_argument(
         '-o',
         '--output',
@@ -56,12 +52,6 @@ def main():
         nargs='?',
         default='trace.json',
         help='Output JSON file')
-    parser.add_argument(
-        '--addr2line',
-        metavar='<path>',
-        nargs='?',
-        default='addr2line',
-        help='`addr2line` binary to use for parsing')
     args = parser.parse_args()
 
     # TraceViewer events
@@ -104,10 +94,16 @@ def main():
 
     # Optionally extract also instruction-level events
     # from the simulation traces
-    if args.traces and args.elf:
-        events += tracevis.parse_traces(args.traces, start=0, end=-1, fmt='snitch',
-                                        addr2line=args.addr2line, use_time=True, pid=1,
-                                        cache=True, elf=args.elf, collapse_call_stack=True)
+    for tvargs in args.tracevis:
+        # Break tracevis argument string into a list of arguments
+        tvargs = tvargs.split()
+        # Add default arguments, and parse all tracevis arguments
+        tvargs.append('--time')
+        tvargs.append('--collapse-call-stack')
+        tvargs = vars(tracevis.parse_args(tvargs))
+        # Add more arguments, and get tracevis events
+        tvargs['pid'] = 1
+        events += tracevis.parse_traces(**tvargs)
 
     # Create TraceViewer JSON object
     tvobj = {}

--- a/util/sim/Simulation.py
+++ b/util/sim/Simulation.py
@@ -226,7 +226,9 @@ class QuestaVCSSimulation(RTLSimulation):
         # Extract the simulation time from the simulation log
         if self.log is not None:
             with open(self.log, 'r') as f:
-                for line in f.readlines():
+                # Read lines from the bottom of the file, since warning and error messages may
+                # also print a time to the log.
+                for line in reversed(f.readlines()):
                     regex = r'Time: (\d+) ([a-z]+)\s+'
                     match = re.search(regex, line)
                     if match:

--- a/util/sim/Simulation.py
+++ b/util/sim/Simulation.py
@@ -200,17 +200,20 @@ class QuestaVCSSimulation(RTLSimulation):
             return super().get_retcode()
         elif self.log is not None:
             # Extract the application's return code from the simulation log
-            with open(self.log, 'r') as f:
-                for line in f.readlines():
-                    regex_success = r'\[SUCCESS\] Program finished successfully'
-                    match_success = re.search(regex_success, line)
-                    if match_success:
-                        return 0
-                    else:
-                        regex_fail = r'\[FAILURE\] Finished with exit code\s+(\d+)'
-                        match = re.search(regex_fail, line)
-                        if match:
-                            return int(match.group(1))
+            if not self.dry_run:
+                with open(self.log, 'r') as f:
+                    for line in f.readlines():
+                        regex_success = r'\[SUCCESS\] Program finished successfully'
+                        match_success = re.search(regex_success, line)
+                        if match_success:
+                            return 0
+                        else:
+                            regex_fail = r'\[FAILURE\] Finished with exit code\s+(\d+)'
+                            match = re.search(regex_fail, line)
+                            if match:
+                                return int(match.group(1))
+            else:
+                return 0
 
     def successful(self):
         # Check that simulation return code matches expected value (in super class)

--- a/util/sim/sim_utils.py
+++ b/util/sim/sim_utils.py
@@ -190,12 +190,9 @@ def print_summary(sims, early_exit=False, dry_run=False):
     Args:
         sims: A list of simulations from the simulation suite.
     """
-    # Header
-    header = '==== Test summary ===='
-    print(header)
-
     # Table
     table = PrettyTable()
+    table.title = 'Test summary'
     table.field_names = [
         'test',
         'launched',

--- a/util/trace/a2l.py
+++ b/util/trace/a2l.py
@@ -53,7 +53,7 @@ class Addr2LineOutput:
 
         # Find all matches and organize them into a list of dictionaries
         stack = [match.groupdict() for match in pattern.finditer(self.raw)]
-        
+
         # Format stack entries
         def format_stack_entry(entry):
             func, line, col = [entry.get(key, None) for key in ['func', 'line', 'col']]

--- a/util/trace/a2l.py
+++ b/util/trace/a2l.py
@@ -12,6 +12,7 @@ import os
 from pathlib import Path
 from functools import lru_cache
 from operator import itemgetter
+import re
 
 
 def unzip(ls):
@@ -24,18 +25,13 @@ def format_function_name(name):
     return name
 
 
-def format_line(num):
-    if num == '?':
-        return -1
-    return int(num)
-
-
 class Addr2LineOutput:
 
     indent_unit = '  '
 
-    def __init__(self, raw):
+    def __init__(self, raw, toolchain='llvm'):
         self.raw = raw
+        self.toolchain = toolchain
 
     # Returns the function stack of the current line.
     # If there was no function inlining, then the function stack
@@ -46,50 +42,89 @@ class Addr2LineOutput:
     def function_stack(self):
         output = self.raw.split('\n')
 
-        functions = output[::2]
-        filepaths, lines = unzip([o.split(':') for o in output[1::2]])
-
+        if self.toolchain == 'llvm':
+            functions = output[::6]
+            if functions[0] == '??':
+                # If function is unknown, there will be no "Function start filename"
+                # and "Function start line" fields
+                filepaths = output[1:2]
+                lines = output[2:3]
+                cols = output[3:4]
+            else:
+                filepaths = output[1::6]
+                lines = output[4::6]
+                cols = output[5::6]
+            filepaths = [re.search(r"Filename: (.+)$", filepath).group(1) for filepath in filepaths]
+            lines = [re.search(r"Line: (\d+)", line).group(1) for line in lines]
+            cols = [re.search(r"Column: (\d+)", col).group(1) for col in cols]
+            cols = [int(col) if col != '0' else None for col in cols]
+        else:
+            functions = output[::2]
+            filepaths, lines = unzip([o.split(':') for o in output[1::2]])
+            cols = [None] * len(lines)
         functions = map(format_function_name, functions)
-        lines = map(format_line, lines)
+        lines = [int(line) if line != '0' else None for line in lines]
 
-        stack = zip(functions, filepaths, lines)
-        stack = [{'func': s[0], 'file': s[1], 'line': s[2]} for s in stack]
-        return stack
+        stack = zip(functions, filepaths, lines, cols)
+        stack = [{'func': s[0], 'file': s[1], 'line': s[2], 'col': s[3]} for s in stack]
+        # Do not create stack if compiler was unable to associate a line number to the address
+        return stack if stack[0]['line'] is not None else None
 
     def function_stack_string(self, short=True):
-        stack = reversed(self.function_stack())
         s = ''
         indent = ''
-        for i, level in enumerate(stack):
-            func, file, line = level.values()
-            if short:
-                file = Path(file).name
-            indent = self.indent_unit * i
-            s += f'{indent}{func} ({file}:{line})\n'
+        stack = self.function_stack()
+        if stack is not None:
+            stack = reversed(self.function_stack())
+            for i, level in enumerate(stack):
+                func, file, line, col = level.values()
+                if short:
+                    file = Path(file).name
+                indent = self.indent_unit * i
+                s += f'{indent}{func} ({file}:{line}'
+                if col is not None:
+                    s += f':{col}'
+                s += ')\n'
+            # Remove final newline
+            s = s[:-1]
         return s
 
     def line(self):
-        file, line = itemgetter('file', 'line')(self.function_stack()[0])
+        if self.function_stack():
+            file, line = itemgetter('file', 'line')(self.function_stack()[0])
 
-        # Open source file
-        src = []
-        try:
-            with open(file, 'r') as f:
-                src = [x.strip() for x in f.readlines()]
-        except OSError:
+            # Open source file
             src = []
+            try:
+                with open(file, 'r') as f:
+                    src = [x for x in f.readlines()]
+            except OSError:
+                src = []
 
-        # Extract line
-        if src and line >= 0:
-            return src[line-1]
-        else:
-            return ''
+            # Extract line
+            if src and line is not None:
+                return src[line-1]
 
     def __str__(self):
-        s = self.function_stack_string()
-        if self.line():
-            indent = self.indent_unit * len(s.strip().split('\n'))
-            s += f'{indent}{self.line()}'
+        s = ''
+        stack = self.function_stack()
+        if stack:
+            col = stack[0]['col']
+            s = self.function_stack_string()
+            line = self.line()
+            if line is not None:
+                # Calculate indentation of original source line
+                stripped_line = line.lstrip()
+                orig_indent = len(line) - len(stripped_line)
+                stripped_line = stripped_line.rstrip()
+                # Calculate indentation to prepend to source line from the function stack string
+                indent = self.indent_unit * len(s.strip().split('\n'))
+                # Append source line to function stack string
+                s += f'\n{indent}{stripped_line}'
+                # Append a column indicator line
+                if col is not None:
+                    new_col = col - orig_indent + len(indent)
+                    s += '\n' + ' ' * (new_col - 1) + '^'
         return s
 
 
@@ -99,6 +134,16 @@ class Elf:
         self.elf = Path(elf)
         self.a2l = a2l_binary
 
+        # We must distinguish between LLVM and GCC toolchains as the latter
+        # does not support the `--verbose` flag
+        if 'riscv64-unknown-elf-addr2line' in a2l_binary:
+            self.toolchain = 'gcc'
+        elif 'llvm-addr2line' in a2l_binary:
+            self.toolchain = 'llvm'
+        else:
+            raise ValueError('addr2line binary expected to be either riscv64-unknown-elf-addr2line'
+                             ' or llvm-addr2line')
+
         assert self.elf.exists(), f'File not found {self.elf}'
 
     @lru_cache(maxsize=1024)
@@ -106,4 +151,6 @@ class Elf:
         if isinstance(addr, str):
             addr = int(addr, 16)
         cmd = f'{self.a2l} -e {self.elf} -f -i {addr:x}'
-        return Addr2LineOutput(os.popen(cmd).read())
+        if self.toolchain == 'llvm':
+            cmd += ' --verbose'
+        return Addr2LineOutput(os.popen(cmd).read(), toolchain=self.toolchain)

--- a/util/trace/annotate.py
+++ b/util/trace/annotate.py
@@ -212,8 +212,11 @@ with open(trace, 'r') as f:
             if trace_start_col < 0:
                 trace_start_col = line.find(addr)
             # Get addr2line information and format it as an assembly comment
-            a2l_output = elf.addr2line(addr)
-            annot = '\n'.join([f'#; {line}' for line in str(a2l_output).split('\n')])
+            a2l_output = str(elf.addr2line(addr))
+            if a2l_output:
+                annot = '\n'.join([f'#; {line}' for line in a2l_output.split('\n')])
+            else:
+                annot = ''
         except (ValueError, IndexError):
             a2l_output = None
             annot = ''

--- a/util/trace/annotate.py
+++ b/util/trace/annotate.py
@@ -268,7 +268,8 @@ with open(trace, 'r') as f:
             if diff:
                 # Compare current and previous call stacks
                 if a2l_output:
-                    funs, files, lines = zip(*[level.values() for level in a2l_output.function_stack()])
+                    funs, files, lines = zip(
+                        *[level.values() for level in a2l_output.function_stack()])
                 else:
                     funs = files = lines = []
                 next_call_stack = assemble_call_stack(funs, files, lines)

--- a/util/trace/gen_trace.py
+++ b/util/trace/gen_trace.py
@@ -41,6 +41,8 @@ import ast
 from ctypes import c_int32, c_uint32
 from collections import deque, defaultdict
 from pathlib import Path
+import traceback
+from itertools import tee, islice, chain
 
 EXTRA_WB_WARN = 'WARNING: {} transactions still in flight for {}.'
 
@@ -1038,6 +1040,15 @@ def fmt_perf_metrics(perf_metrics: list, idx: int, omit_keys: bool = True):
     return '\n'.join(ret)
 
 
+# -------------------- Utils --------------------
+
+
+def current_and_next(iterable):
+    currs, nexts = tee(iterable, 2)
+    nexts = chain(islice(nexts, 1, None), [None])
+    return zip(currs, nexts)
+
+
 # -------------------- Main --------------------
 
 
@@ -1115,16 +1126,26 @@ def main():
         ]  # all values initially 0, also 'start' time of measurement 0
         perf_metrics[0]['start'] = None
         # Parse input line by line
-        for line in line_iter:
+        for lineno, (line, nextl) in enumerate(current_and_next(line_iter)):
             if line:
-                ann_insn, time_info, empty = annotate_insn(
-                    line, gpr_wb_info, fpr_wb_info, fseq_info, perf_metrics, False,
-                    time_info, args.offl, not args.saddr, args.permissive, dma_trans)
-                if perf_metrics[0]['start'] is None:
-                    perf_metrics[0]['tstart'] = time_info[0] / 1000
-                    perf_metrics[0]['start'] = time_info[1]
-                if not empty:
-                    print(ann_insn, file=file)
+                try:
+                    ann_insn, time_info, empty = annotate_insn(
+                        line, gpr_wb_info, fpr_wb_info, fseq_info, perf_metrics, False,
+                        time_info, args.offl, not args.saddr, args.permissive, dma_trans)
+                    if perf_metrics[0]['start'] is None:
+                        perf_metrics[0]['tstart'] = time_info[0] / 1000
+                        perf_metrics[0]['start'] = time_info[1]
+                    if not empty:
+                        print(ann_insn, file=file)
+                except Exception:
+                    message = 'Exception occured while processing '
+                    if not nextl:
+                        message += 'last line. Did the simulation terminate?'
+                    else:
+                        message += 'line {lineno}.'
+                    print(traceback.format_exc(), file=sys.stderr)
+                    print(message, file=sys.stderr)
+                    return 1
             else:
                 break  # Nothing more in pipe, EOF
         perf_metrics[-1]['tend'] = time_info[0] / 1000

--- a/util/trace/tracevis.py
+++ b/util/trace/tracevis.py
@@ -252,7 +252,7 @@ def parse_trace(filename, kwargs):
         events += flush(lah, buf, **kwargs)
 
         print(f' parsed {lines-fails} of {lines} lines', file=sys.stderr)
-    
+
         # Assign a per-trace unique TID or PID to all events
         for event in events:
             if kwargs['collapse_call_stack']:

--- a/util/trace/tracevis.py
+++ b/util/trace/tracevis.py
@@ -115,7 +115,9 @@ def flush(lah, buf, **kwargs):
         event['dur'] = 1 if fmt == 'banshee' else duration
         # The thread ID is used to group events in a single TraceViewer row
         if not collapse_call_stack:
-            event['tid'] = a2l_info.function_stack[0]['func']
+            stack = a2l_info.function_stack()
+            if stack is not None:
+                event['tid'] = stack[0]['func']
         if fmt == 'banshee':
             # Banshee stores all traces in a single file
             event['tid'] = priv
@@ -272,13 +274,11 @@ def parse_traces(traces, **kwargs):
 
     # Iterate traces
     events = []
-    for i, filename in enumerate(traces):
+    for filename in traces:
 
-        # Extract hartid from filename or use current index
-        # TODO doesn't work with hex numbers
-        # parsed_nums = re.findall(r'\d+', filename)
-        # hartid = int(parsed_nums[-1]) if len(parsed_nums) else i
-        hartid = i
+        # Extract hartid from filename
+        pattern = r'trace_hart_([0-9a-fA-F]+)\.txt$'
+        hartid = int(re.search(pattern, filename).group(1), 16)
 
         # Extract TraceViewer events from trace
         trace_events = parse_trace(filename, **kwargs)
@@ -319,7 +319,7 @@ def main(**kwargs):
 
 
 # Parse command-line args
-def parse_args():
+def parse_args(args=None):
     # Argument parsing
     parser = argparse.ArgumentParser('tracevis', allow_abbrev=True)
     parser.add_argument(
@@ -379,7 +379,7 @@ def parse_args():
         type=int,
         default=-1,
         help='Last line to parse (inclusive)')
-    return parser.parse_args()
+    return parser.parse_args(args)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
- The simulation time would be taken from the first line printing the time, this included error messages. We fix this by taking the last line printing the time.
- We use the `PrettyTable` title feature to replace our custom title output for the test summary table.
- Dry simulation runs do not produce any log file. We should not attempt to read the return code from the log file when the run is dry.
- Add column field to annotated simulation traces. This is possible only with LLVM toolchains, so we must handle GCC and LLVM toolchains differently.
- Previously, lines without timestamps, e.g. FPU instructions executed in the same cycle as an integer instruction, were being parsed incorrectly, so they would not be annotated. Now we use a regex to handle these lines properly.
- Fix https://github.com/pulp-platform/snitch_cluster/issues/85.
- In some corner cases, `addr2line` does not display all information for a certain function. We shift to regular expressions to parse `addr2line` output and correct this condition. 
- Extend trace visualization utilities to include CVA6 trace in heterogeneous systems including Snitch cluster.
- Extend `tracevis.py` to process traces in parallel.
- Extend `gen_trace.py` to print the line number on an exception.