### PR TITLE
sw: Fix invalid inline assembly in `snrt_dma_wait_channel`

### DIFF
--- a/sw/snRuntime/src/dma.h
+++ b/sw/snRuntime/src/dma.h
@@ -232,7 +232,7 @@ inline void snrt_dma_wait_channel(snrt_dma_txid_t tid, uint32_t channel) {
         "blez t0, 1b \n" ::"i"(
             R_TYPE_ENCODE(DMSTAT_FUNCT7, 6, 0, XDMA_FUNCT3, 5, OP_CUSTOM1)),
         "r"(tid), "r"(cfg)
-        : "t0", "t1");
+        : "t0");
 }
 
 /// Block until all operation on the DMA ceases.


### PR DESCRIPTION
The inline assembly uses `t1` both as input operand (via the `cfg` variable) and within the clobber list. This is illegal but due to a bug in clang 12 that has been fixed in clang 14 has gone unnoticed. Quoting from the GCC documentation (https://gcc.gnu.org/onlinedocs/gcc/Extended-Asm.html#Clobbers-and-Scratch-Registers-1):

> Clobber descriptions may not in any way overlap with an input or output operand. For example, you may not have an operand describing a register class with one member when listing that register in the clobber list. Variables declared to live in specific registers (see Variables in Specified Registers) and used as asm input or output operands must have no part mentioned in the clobber description.

This correctly emits an error if using Clang 14 or any version of GCC: https://godbolt.org/z/17zrdK18e

The fix is to simply remove the clobber of `t1` which is safe to do as it is only used as input.