### PR TITLE
util: Replace `spike-dasm` in favor of `llvm-mc`

### DIFF
--- a/iis-setup.sh
+++ b/iis-setup.sh
@@ -24,11 +24,3 @@ rm -rf tmp
 
 # Install local packages in editable mode.
 pip install -e .
-
-# Install spike-dasm
-mkdir tools/
-cd tools/
-wget https://raw.githubusercontent.com/pulp-platform/riscv-isa-sim/snitch/iis-install-spike-dasm.sh
-chmod +x iis-install-spike-dasm.sh && ./iis-install-spike-dasm.sh && rm iis-install-spike-dasm.sh
-cd -
-export PATH=$(pwd)/tools:$PATH

--- a/target/snitch_cluster/Makefile
+++ b/target/snitch_cluster/Makefile
@@ -260,5 +260,5 @@ help:
 	@echo -e "${Blue}clean-vsim       ${Black}Clean all build directories and temporary files for Questasim simulation."
 	@echo -e ""
 	@echo -e "Additional useful targets from the included Makefrag:"
-	@echo -e "${Blue}traces           ${Black}Generate the better readable traces in .logs/trace_hart_<hart_id>.txt with spike-dasm."
+	@echo -e "${Blue}traces           ${Black}Generate the better readable traces in .logs/trace_hart_<hart_id>.txt."
 	@echo -e "${Blue}annotate         ${Black}Annotate the better readable traces in .logs/trace_hart_<hart_id>.s with the source code related with the retired instructions."

--- a/util/trace/gen_trace.py
+++ b/util/trace/gen_trace.py
@@ -359,9 +359,7 @@ def load_opcodes():
 def disasm_inst(hex_inst, mc_exec='llvm-mc', mc_flags='-disassemble -mcpu=snitch'):
     """Disassemble a single RISC-V instruction using llvm-mc."""
     # Reverse the endianness of the hex instruction
-    inst_fmt = ' '.join(
-        [f'0x{hex_inst[i:i+2]}' for i in range(0, len(hex_inst), 2)][::-1]
-    )
+    inst_fmt = ' '.join(f'0x{byte:02x}' for byte in bytes.fromhex(hex_inst)[::-1])
 
     # Use llvm-mc to disassemble the binary instruction
     result = subprocess.run(

--- a/util/trace/gen_trace.py
+++ b/util/trace/gen_trace.py
@@ -1147,7 +1147,7 @@ def main():
     )
     parser.add_argument(
         '--mc-flags',
-        default='-mcpu=snitch',
+        default='-disassemble -mcpu=snitch',
         help='Flags to pass to the llvm-mc executable'
     )
 

--- a/util/trace/gen_trace.py
+++ b/util/trace/gen_trace.py
@@ -365,13 +365,15 @@ def disasm_inst(hex_inst, mc_exec='llvm-mc', mc_flags='-disassemble -mcpu=snitch
 
     # Use llvm-mc to disassemble the binary instruction
     result = subprocess.run(
-        f'echo {inst_fmt} | {mc_exec} {mc_flags}',
-        shell=True,
+        [mc_exec] + mc_flags.split(),
+        input=inst_fmt,
         capture_output=True,
+        text=True,
+        check=True,
     )
 
     # Extract disassembled instruction from llvm-mc output
-    return result.stdout.decode().splitlines()[-1].strip().replace('\t', ' ')
+    return result.stdout.splitlines()[-1].strip().replace('\t', ' ')
 
 
 def flt_op_vlen(insn: str, op_type: str) -> int:


### PR DESCRIPTION
For trace generation we currently use `spike-dasm` to dissassemble single instructions from core log files. The problem with `spike-dasm` is that is an external executable, that needs to be maintained by us. For instance, new instructions need to be added manually to `spike-dasm` for decoding.

The better alternative is [`llvm-mc`](https://llvm.org/docs/CommandGuide/llvm-mc.html) which is a CLI tool that is compiled alongside LLVM. This means all our custom ISA extensions supported by the LLVM toolchain are also automatically supported by `llvm-mc`  and don't have to be added manually to the dissasembler as before.