### PR TITLE
ci: Fix elaboration flow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,7 +58,6 @@ jobs:
       - name: Build Hardware
         working-directory: target/snitch_cluster
         run: |
-          pip install -r $(bender path idma)/requirements.txt
           make CFG_OVERRIDE=cfg/github-ci.hjson VLT_JOBS=1 bin/snitch_cluster.vlt
       - name: Run Tests
         working-directory: target/snitch_cluster

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -56,7 +56,6 @@ jobs:
       - name: Generate RTL sources
         working-directory: target/snitch_cluster
         run: |
-          pip install -r $(bender path idma)/requirements.txt
           make rtl
       # For some reason, the checkout is done by a different user,
       # than that running `git diff` (root, possibly due to Docker).

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -159,7 +159,7 @@ snitch-cluster-mchan-vsim:
 # Non-free #
 ############
 
-# nonfree:
-#   script:
-#     - make nonfree
-#     - make elab
+nonfree:
+  script:
+    - make nonfree
+    - make elab

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -15,7 +15,6 @@ variables:
 
 before_script:
   source iis-setup.sh
-  pip install $($BENDER path idma)/requirements.txt
 
 ##############
 # Build docs #

--- a/Bender.lock
+++ b/Bender.lock
@@ -71,7 +71,7 @@ packages:
     dependencies:
     - common_cells
   idma:
-    revision: 0a0c113434aee743923d9e85631de009b4f00847
+    revision: 1a42da9d5c76f1cff0bcdaaacc474ed85631d734
     version: null
     source:
       Git: https://github.com/pulp-platform/iDMA
@@ -83,8 +83,8 @@ packages:
     - obi
     - register_interface
   obi:
-    revision: c2141a653c755461ff44f61d12aeb5d99fc8e760
-    version: 0.1.3
+    revision: 5321106817e177d6c16ecc4daa922b96b1bc946b
+    version: 0.1.5
     source:
       Git: https://github.com/pulp-platform/obi.git
     dependencies:

--- a/Bender.yml
+++ b/Bender.yml
@@ -27,7 +27,7 @@ dependencies:
   tech_cells_generic: { git: https://github.com/pulp-platform/tech_cells_generic, version:  0.2.11  }
   riscv-dbg:          { git: https://github.com/pulp-platform/riscv-dbg,          version:  0.8.0   }
   cluster_icache:     { git: https://github.com/pulp-platform/cluster_icache.git, version:  0.1.0   }
-  idma:               { git: https://github.com/pulp-platform/iDMA,               rev:      snitch-tracing }
+  idma:               { git: https://github.com/pulp-platform/iDMA,               rev: __deploy__9cbcd30__snitch-tracing }
 
 export_include_dirs:
   - hw/reqrsp_interface/include

--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ ROOT = $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
 ############
 
 NONFREE_REMOTE ?= git@iis-git.ee.ethz.ch:pulp-restricted/snitch-cluster-nonfree.git
-NONFREE_COMMIT ?= 214380a8c6af4cdd3d53a5b74cfaf462da877be2
+NONFREE_COMMIT ?= e30961e20a23a76442da27d2ba07c9fe20f3b575
 NONFREE_DIR = $(ROOT)/nonfree
 
 all: nonfree

--- a/iis-setup.sh
+++ b/iis-setup.sh
@@ -20,7 +20,6 @@ source .venv/bin/activate
 # occurring when the /tmp folder is filled by other processes.
 mkdir tmp
 TMPDIR=tmp pip install -r python-requirements.txt
-TMPDIR=tmp pip install -r $($BENDER path idma)/requirements.txt
 rm -rf tmp
 
 # Install local packages in editable mode.

--- a/target/snitch_cluster/Makefile
+++ b/target/snitch_cluster/Makefile
@@ -151,19 +151,9 @@ include $(ROOT)/target/snitch_cluster/sw.mk
 # RTL #
 #######
 
-# Include iDMA Makefile to generate prerequisite iDMA sources
-include $(shell $(BENDER) path idma)/idma.mk
-
 GENERATED_RTL_SOURCES  = $(PERIPH_DIR)/snitch_cluster_peripheral_reg_top.sv
 GENERATED_RTL_SOURCES += $(PERIPH_DIR)/snitch_cluster_peripheral_reg_pkg.sv
 GENERATED_RTL_SOURCES += $(GENERATED_DIR)/snitch_cluster_wrapper.sv
-GENERATED_RTL_SOURCES += $(IDMA_ROOT)/target/rtl/idma_inst64_top.sv
-GENERATED_RTL_SOURCES += $(IDMA_ROOT)/target/rtl/include/idma/tracer.svh
-
-# Add dependency on DMA header files
-VSIM_SOURCES += $(IDMA_ROOT)/target/rtl/include/idma/tracer.svh
-VLT_SOURCES  += $(IDMA_ROOT)/target/rtl/include/idma/tracer.svh
-VCS_SOURCES  += $(IDMA_ROOT)/target/rtl/include/idma/tracer.svh
 
 .PHONY: rtl clean-rtl
 


### PR DESCRIPTION
Fixes and enables again the elaboration flow thanks to some [upstream changes](https://github.com/pulp-platform/iDMA/pull/52/commits/9cbcd3085a1881aa46806ca61a5053b86e9c9562) in the iDMA repo. Also revert back generation of DMA sources, which are automatically included in the `__deeploy__` branches