### PR TITLE
target: Fix testbench clock period regression from #168

### DIFF
--- a/target/snitch_cluster/test/testharness.sv
+++ b/target/snitch_cluster/test/testharness.sv
@@ -47,7 +47,9 @@ module testharness;
   //  VIP  //
   ///////////
 
-  vip_snitch_cluster vip (.*);
+  vip_snitch_cluster #(
+    .ClkPeriod(1ns)
+  ) vip (.*);
 
   initial begin
     // Wait for the reset

--- a/target/snitch_cluster/test/vip_snitch_cluster.sv
+++ b/target/snitch_cluster/test/vip_snitch_cluster.sv
@@ -6,7 +6,7 @@ module vip_snitch_cluster
   import snitch_cluster_pkg::*;
 #(
   // Timing
-  parameter time ClkPeriod = 10ns
+  parameter realtime ClkPeriod = 10ns
 ) (
   output logic clk,
   output logic rst_n,

--- a/util/container/Dockerfile
+++ b/util/container/Dockerfile
@@ -5,7 +5,7 @@
 # Docker container for Snitch development.
 
 # 1. Stage: Use the verilator container to get the Verilator binary.
-ARG VERILATOR_VERSION=5.032
+ARG VERILATOR_VERSION=5.034
 ARG UBUNTU_VERSION=22.04
 
 # 1. Stage: Install additional IIS tools


### PR DESCRIPTION
Revert the testbench clock period back to 1ns from 10ns, after it was unadvertedly changed with #168.

This PR was split from https://github.com/pulp-platform/snitch_cluster/pull/204, see discussion thereof for more details.

- [x] Wait for Verilator release v5.034
- [x] Wait for https://github.com/verilator/verilator/pull/5885 to be merged, and v5.034 Docker container to be deployed