### PR TITLE
Improve CI

### DIFF
--- a/.github/workflows/gitlab-ci.yaml
+++ b/.github/workflows/gitlab-ci.yaml
@@ -4,7 +4,9 @@
 
 # Some CI tests run on our GitLab servers due to licenses and tools
 name: gitlab-ci
-on: [push, pull_request, workflow_dispatch]
+# Skip on pull requests as forks don't have required secrets,
+# and pull requests from own repo already trigger a push event.
+on: [push, workflow_dispatch]
 jobs:
   gitlab-ci:
     name: Internal Gitlab CI
@@ -12,11 +14,9 @@ jobs:
     steps:
       - name: Check Gitlab CI
         uses: pulp-platform/pulp-actions/gitlab-ci@v2.1.0
-        # Skip on forks or pull requests from forks due to missing secrets.
+        # Skip on forks due to missing secrets.
         if: >
-          github.repository == 'pulp-platform/snitch_cluster' &&
-          (github.event_name != 'pull_request' ||
-          github.event.pull_request.head.repo.full_name == github.repository)
+          github.repository == 'pulp-platform/snitch_cluster'
         with:
           domain: iis-git.ee.ethz.ch
           repo: github-mirror/snitch_cluster

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -12,15 +12,40 @@ variables:
   CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER: /usr/pack/gcc-9.2.0-af/linux-x64/bin/gcc
   LLVM_SYS_120_PREFIX: /usr/pack/llvm-12.0.1-af
   CMAKE: cmake-3.18.1
+  # Override pip cache directory
+  PIP_CACHE_DIR: "$CI_PROJECT_DIR/.cache/pip"
 
-before_script:
-  source iis-setup.sh
+default:
+  before_script:
+    source iis-setup.sh
+  cache: &global_cache
+    key:
+      files:
+        - pyproject.toml
+    paths:
+      - .cache/pip
+    policy: pull
+
+
+#########
+# Setup #
+#########
+
+setup:
+  cache:
+    # inherit all global cache settings
+    <<: *global_cache
+    # override the policy
+    policy: pull-push
+  script:
+    - echo "Setup completed."
 
 ##############
 # Build docs #
 ##############
 
 docs:
+  needs: [setup]
   script:
     - make docs
 
@@ -29,6 +54,7 @@ docs:
 #####################
 
 pytest:
+  needs: [setup]
   script:
     - pytest
 
@@ -37,6 +63,7 @@ pytest:
 #################################
 
 snitch-cluster-sw:
+  needs: [setup]
   script:
     - cd target/snitch_cluster
     - make sw
@@ -46,6 +73,7 @@ snitch-cluster-sw:
     expire_in: 1 day
 
 snitch-cluster-sw-banshee:
+  needs: [setup]
   script:
     - cd target/snitch_cluster
     - make SELECT_RUNTIME=banshee sw
@@ -65,7 +93,7 @@ snitch-cluster-sw-banshee:
 # - snitch_dma
 # - snitch
 snitch-ip-tests:
-  needs: []
+  needs: [setup]
   parallel:
     matrix:
       - IP:
@@ -85,7 +113,7 @@ snitch-ip-tests:
 
 # Verilator
 snitch-cluster-vlt:
-  needs: [snitch-cluster-sw]
+  needs: [setup, snitch-cluster-sw]
   script:
     - cd target/snitch_cluster
     - make bin/snitch_cluster.vlt
@@ -93,7 +121,7 @@ snitch-cluster-vlt:
 
 # VCS
 snitch-cluster-vcs:
-  needs: [snitch-cluster-sw]
+  needs: [setup, snitch-cluster-sw]
   script:
     - cd target/snitch_cluster
     - make bin/snitch_cluster.vcs
@@ -101,7 +129,7 @@ snitch-cluster-vcs:
 
 # Questa
 snitch-cluster-vsim:
-  needs: [snitch-cluster-sw]
+  needs: [setup, snitch-cluster-sw]
   script:
     - cd target/snitch_cluster
     - make bin/snitch_cluster.vsim
@@ -114,7 +142,7 @@ snitch-cluster-vsim:
 
 # Banshee
 snitch-cluster-banshee:
-  needs: [snitch-cluster-sw-banshee]
+  needs: [setup, snitch-cluster-sw-banshee]
   variables:
     SNITCH_LOG: info
   script:
@@ -130,6 +158,7 @@ snitch-cluster-banshee:
 
 # Tests requiring hardware FDIV unit
 snitch-cluster-fdiv-vsim:
+  needs: [setup]
   script:
     - cd target/snitch_cluster
     - make CFG_OVERRIDE=cfg/fdiv.json sw
@@ -140,6 +169,7 @@ snitch-cluster-fdiv-vsim:
 
 # Test OmegaNet TCDM interconnect
 snitch-cluster-omega-vsim:
+  needs: [setup]
   script:
     - cd target/snitch_cluster
     - make CFG_OVERRIDE=cfg/omega.json sw
@@ -148,6 +178,7 @@ snitch-cluster-omega-vsim:
 
 # Test Multi-channel DMA
 snitch-cluster-mchan-vsim:
+  needs: [setup]
   script:
     - cd target/snitch_cluster
     - make CFG_OVERRIDE=cfg/dma_mchan.json sw
@@ -159,6 +190,7 @@ snitch-cluster-mchan-vsim:
 ############
 
 nonfree:
+  needs: [setup]
   script:
     - make nonfree
     - make elab


### PR DESCRIPTION
- The internal Gitlab CI job in the Github CI was run on both the pull request and the push trigger, which both occur when pushing to a pull request from the same repository. We avoid these duplicate runs by disabling the pull request trigger.
- Previously, every job in the Gitlab CI was creating a virtual environment and installing corresponding dependencies. This likely favoured the occurrence of "Out of disk space" errors. Now we run a "setup" job at the beginning, and store the pip cache as an artifact. All other jobs depend on this job, so they will inherit the installed cache folder, and the `iis-setup.sh` script does not need to download all the packages again. Caching the virtual environment entirely has been avoided as virtual environments are theoretically not relocatable.