### PR TITLE
ci: Enable pull requests from forks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,11 @@
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
-# Run functional regression checks
+# Run regression tests on Snitch's Docker container.
+# Pull requests from forks cannot deploy the Docker container due to missing
+# secrets, thus we only enable this workflow on push triggers.
 name: ci
-on: [push, pull_request]
+on: [push]
 
 jobs:
 
@@ -15,9 +17,6 @@ jobs:
   build-docker:
     name: Deploy Docker image
     runs-on: ubuntu-22.04
-    if: >
-      github.event_name != 'pull_request' ||
-      github.event.pull_request.head.repo.full_name != github.repository
     # Export Docker image name used by dependent jobs
     outputs:
       image_name: ${{ steps.image_name.outputs.image_name }}
@@ -62,9 +61,6 @@ jobs:
     name: Build documentation
     runs-on: ubuntu-22.04
     needs: build-docker
-    if: >
-      github.event_name != 'pull_request' ||
-      github.event.pull_request.head.repo.full_name != github.repository
     container:
       image: ${{ needs.build-docker.outputs.image_name }}
     steps:
@@ -78,7 +74,7 @@ jobs:
     needs: build-docker
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     container:
-      image: ghcr.io/pulp-platform/snitch_cluster:${{ github.ref_name }}
+      image: ${{ needs.build-docker.outputs.image_name }}
     steps:
       - uses: actions/checkout@v2
       # For some reason, the checkout is done by a different user
@@ -102,9 +98,6 @@ jobs:
     name: Python unit tests
     runs-on: ubuntu-22.04
     needs: build-docker
-    if: >
-      github.event_name != 'pull_request' ||
-      github.event.pull_request.head.repo.full_name != github.repository
     container:
       image: ${{ needs.build-docker.outputs.image_name }}
     steps:
@@ -120,9 +113,6 @@ jobs:
     name: Simulate SW on Snitch Cluster w/ Verilator
     runs-on: ubuntu-22.04
     needs: build-docker
-    if: >
-      github.event_name != 'pull_request' ||
-      github.event.pull_request.head.repo.full_name != github.repository
     container:
       image: ${{ needs.build-docker.outputs.image_name }}
     steps:
@@ -170,9 +160,6 @@ jobs:
     name: Check Sources Up-to-Date
     runs-on: ubuntu-22.04
     needs: build-docker
-    if: >
-      github.event_name != 'pull_request' ||
-      github.event.pull_request.head.repo.full_name != github.repository
     container:
       image: ${{ needs.build-docker.outputs.image_name }}
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,20 @@ jobs:
     if: >
       github.event_name != 'pull_request' ||
       github.event.pull_request.head.repo.full_name != github.repository
+    # Export Docker image name used by dependent jobs
+    outputs:
+      image_name: ${{ steps.image_name.outputs.image_name }}
     steps:
+      - name: Define Docker image name
+        id: image_name
+        # To satisfy Docker tag naming requirements, we replace all slashes
+        # in the ref name with dashes.
+        run: |
+          SANITIZED_REF_NAME="${GITHUB_REF_NAME//\//-}"
+          echo "Sanitized GITHUB_REF_NAME: $SANITIZED_REF_NAME"
+          IMAGE_NAME="ghcr.io/${GITHUB_REPOSITORY}:${SANITIZED_REF_NAME}"
+          echo "Image name: $IMAGE_NAME"
+          echo "image_name=$IMAGE_NAME" >> $GITHUB_OUTPUT
       - name: Free Disk Space (Ubuntu)
         uses: jlumbroso/free-disk-space@main
         with:
@@ -39,7 +52,7 @@ jobs:
           cache-to: type=gha,mode=max`
           file: util/container/Dockerfile
           push: true
-          tags: ghcr.io/${{ github.repository_owner }}/snitch_cluster:${{ github.ref_name }}
+          tags: ${{ steps.image_name.outputs.image_name }}
 
   ########
   # Docs #
@@ -53,7 +66,7 @@ jobs:
       github.event_name != 'pull_request' ||
       github.event.pull_request.head.repo.full_name != github.repository
     container:
-      image: ghcr.io/${{ github.repository_owner }}/snitch_cluster:${{ github.ref_name }}
+      image: ${{ needs.build-docker.outputs.image_name }}
     steps:
       - uses: actions/checkout@v2
       - name: Build docs
@@ -93,7 +106,7 @@ jobs:
       github.event_name != 'pull_request' ||
       github.event.pull_request.head.repo.full_name != github.repository
     container:
-      image: ghcr.io/${{ github.repository_owner }}/snitch_cluster:${{ github.ref_name }}
+      image: ${{ needs.build-docker.outputs.image_name }}
     steps:
       - uses: actions/checkout@v2
       - name: Run pytest
@@ -111,7 +124,7 @@ jobs:
       github.event_name != 'pull_request' ||
       github.event.pull_request.head.repo.full_name != github.repository
     container:
-      image: ghcr.io/${{ github.repository_owner }}/snitch_cluster:${{ github.ref_name }}
+      image: ${{ needs.build-docker.outputs.image_name }}
     steps:
       - uses: actions/checkout@v2
         with:
@@ -161,7 +174,7 @@ jobs:
       github.event_name != 'pull_request' ||
       github.event.pull_request.head.repo.full_name != github.repository
     container:
-      image: ghcr.io/${{ github.repository_owner }}/snitch_cluster:${{ github.ref_name }}
+      image: ${{ needs.build-docker.outputs.image_name }}
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
This PR implements two **contributions**:

- Replace slashes with hyphens in Github ref names, to comply with Docker tag naming requirements.
- Disable main workflow runs on pull requests.

The second is motivated by pull requests from forks not being able to deploy the Docker container on this repo. This seems to be due to missing `GITHUB_TOKEN` **permissions**. It also doesn't seem to be possible to use the `pull_request_target` trigger to this end. Nonetheless, the workflow can still be run on the fork itself.

While the Docker container could also just be built and tested in the CI run, without requiring access to secrets, this leads to a lot of **boilerplate** code.

Our **solution** going forward is to simply ask contributors to enable the CI on their public fork, so that the maintainers can check the CI status there directly.