### PR TITLE
Eliminate PIP cache and force torch cpu only install

### DIFF
--- a/util/container/Dockerfile
+++ b/util/container/Dockerfile
@@ -81,7 +81,11 @@ ARG VIRTUAL_ENV="/root/.venvs/snitch_cluster"
 RUN python${PYTHON_VERSION} -m venv ${VIRTUAL_ENV}
 
 # Upgrade pip and install packages using the virtual environment's pip
+# Don't cache pip files to avoid polluting the docker container
+# Install torch from the cpu only index to avoid installing the GPU versio
+ARG PIP_NO_CACHE_DIR=1
 RUN ${VIRTUAL_ENV}/bin/pip install --upgrade pip && \
+    ${VIRTUAL_ENV}/bin/pip install torch --index-url https://download.pytorch.org/whl/cpu && \
     ${VIRTUAL_ENV}/bin/pip install .
 
 # Copy the tools from the builder stage


### PR DESCRIPTION
The current docker container is ~12.5GB - a lot of which is nvidia stuff brought in by torch and pip cache. This change modifies the dockerfile to explicitly install the cpu only version of torch and disables the PIP cache to shrink the docker image from 12.5GB to about 4.5GB.