### PR TITLE
treewide: Improve integration in systems

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -124,10 +124,10 @@ jobs:
           submodules: 'recursive'
       - name: Hash Verilator prerequisites
         id: verilator-hash
-        uses: colluca/list-make-prerequisites@v1.0.2
+        uses: colluca/list-make-prerequisites@v1.0.3
         with:
           working-directory: target/snitch_cluster
-          target: bin/snitch_cluster.vlt
+          target: verilator
           flags: --recursive
       - name: Set up cache for Verilator build
         id: verilator-cache
@@ -141,7 +141,7 @@ jobs:
         if: steps.verilator-cache.outputs.cache-hit != 'true'
         working-directory: target/snitch_cluster
         run: |
-          make CFG_OVERRIDE=cfg/github-ci.json VLT_JOBS=1 bin/snitch_cluster.vlt
+          make CFG_OVERRIDE=cfg/github-ci.json VLT_JOBS=1 verilator
       - name: Build Software
         working-directory: target/snitch_cluster
         run: |

--- a/Bender.yml
+++ b/Bender.yml
@@ -188,10 +188,10 @@ sources:
   # target/snitch_cluster
   - target: snitch_cluster_wrapper
     files:
-      - target/snitch_cluster/generated/snitch_cluster_pkg.sv
+      - target/snitch_cluster/.generated/snitch_cluster_pkg.sv
   - target: all(snitch_cluster_wrapper, not(postlayout))
     files:
-      - target/snitch_cluster/generated/snitch_cluster_wrapper.sv
+      - target/snitch_cluster/.generated/snitch_cluster_wrapper.sv
   - target: all(snitch_cluster_wrapper, postlayout)
     files:
       - nonfree/gf12/fusion/runs/0/out/15/snitch_cluster_wrapper.v

--- a/docs/ug/tutorial.md
+++ b/docs/ug/tutorial.md
@@ -27,17 +27,17 @@ To run software on Snitch without a physical chip, you will need a simulation mo
 
 === "Verilator"
     ```shell
-    make bin/snitch_cluster.vlt
+    make verilator
     ```
 
 === "Questa"
     ```shell
-    make DEBUG=ON bin/snitch_cluster.vsim
+    make DEBUG=ON vsim
     ```
 
 === "VCS"
     ```shell
-    make bin/snitch_cluster.vcs
+    make vcs
     ```
 
 These commands compile the RTL sources respectively in `work-vlt`, `work-vsim` and `work-vcs`. Additionally, common C++ testbench sources (e.g. the [frontend server (fesvr)](https://github.com/riscv-software-src/riscv-isa-sim)) are compiled under `work`. Each command will also generate a script or an executable (e.g. `bin/snitch_cluster.vsim`) which we can use to simulate software on Snitch, as we will see in section [Running a simulation](#running-a-simulation).
@@ -54,7 +54,7 @@ In the [`cfg`](https://github.com/pulp-platform/{{ repo }}/blob/{{ branch }}/tar
 The command you previously executed automatically generated the RTL sources from the templates, and it implicitly used the default configuration file. In this configuration the FPU is not equipped with a floating-point divide and square-root unit.
 To override the default configuration file, e.g. to use the omega TCDM interconnect, define the following variable when you invoke `make`:
 ```shell
-make CFG_OVERRIDE=cfg/omega.json bin/snitch_cluster.vlt
+make CFG_OVERRIDE=cfg/omega.json verilator
 ```
 
 If you want to use a custom configuration, just point `CFG_OVERRIDE` to the path of your configuration file.
@@ -268,11 +268,11 @@ In your `tutorial` folder, create a new file named `app.mk` with the following c
 
 ```make
 APP              := tutorial
-$(APP)_BUILD_DIR := $(ROOT)/target/snitch_cluster/sw/apps/$(APP)/build
-SRCS             := $(ROOT)/target/snitch_cluster/sw/apps/$(APP)/src/$(APP).c
-$(APP)_INCDIRS   := $(ROOT)/target/snitch_cluster/sw/apps/$(APP)/data
+$(APP)_BUILD_DIR := $(SN_ROOT)/target/snitch_cluster/sw/apps/$(APP)/build
+SRCS             := $(SN_ROOT)/target/snitch_cluster/sw/apps/$(APP)/src/$(APP).c
+$(APP)_INCDIRS   := $(SN_ROOT)/target/snitch_cluster/sw/apps/$(APP)/data
 
-include $(ROOT)/target/snitch_cluster/sw/apps/common.mk
+include $(SN_ROOT)/target/snitch_cluster/sw/apps/common.mk
 ```
 
 This file will be included in the top-level Makefile, compiling your source code into an executable with the name provided in the `APP` variable.

--- a/sw/dnn/common.mk
+++ b/sw/dnn/common.mk
@@ -4,6 +4,6 @@
 #
 # Luca Colagrande <colluca@iis.ee.ethz.ch>
 
-include $(ROOT)/sw/apps/common.mk
-$(APP)_INCDIRS += $(ROOT)/sw/dnn/src
-$(APP)_INCDIRS += $(ROOT)/sw/blas
+include $(SN_ROOT)/sw/apps/common.mk
+$(APP)_INCDIRS += $(SN_ROOT)/sw/dnn/src
+$(APP)_INCDIRS += $(SN_ROOT)/sw/blas

--- a/target/common/rtl.mk
+++ b/target/common/rtl.mk
@@ -1,0 +1,48 @@
+# Copyright 2025 ETH Zurich and University of Bologna.
+# Solderpad Hardware License, Version 0.51, see LICENSE for details.
+# SPDX-License-Identifier: SHL-0.51
+
+# Directories
+SN_BOOTROM_DIR ?= $(SN_TARGET_DIR)/test
+
+# Templates
+SN_CLUSTER_WRAPPER_TPL = $(SN_HW_DIR)/snitch_cluster/src/snitch_cluster_wrapper.sv.tpl
+SN_CLUSTER_PKG_TPL     = $(SN_HW_DIR)/snitch_cluster/src/snitch_cluster_pkg.sv.tpl
+
+# Generated RTL sources
+SN_CLUSTER_WRAPPER    = $(SN_GEN_DIR)/snitch_cluster_wrapper.sv
+SN_CLUSTER_PKG        = $(SN_GEN_DIR)/snitch_cluster_pkg.sv
+SN_CLUSTER_PERIPH_TOP = $(SN_PERIPH_DIR)/snitch_cluster_peripheral_reg_top.sv
+SN_CLUSTER_PERIPH_PKG = $(SN_PERIPH_DIR)/snitch_cluster_peripheral_reg_pkg.sv
+SN_BOOTROM            = $(SN_BOOTROM_DIR)/snitch_bootrom.sv
+
+# All generated RTL sources
+SN_GEN_RTL_SRCS = $(SN_CLUSTER_WRAPPER) $(SN_CLUSTER_PKG) $(SN_CLUSTER_PERIPH_TOP) $(SN_CLUSTER_PERIPH_PKG) $(SN_BOOTROM) 
+
+# CLUSTERGEN rules
+$(eval $(call sn_cluster_gen_rule,$(SN_CLUSTER_WRAPPER),$(SN_CLUSTER_WRAPPER_TPL)))
+$(eval $(call sn_cluster_gen_rule,$(SN_CLUSTER_PKG),$(SN_CLUSTER_PKG_TPL)))
+
+# REGGEN rules
+$(SN_CLUSTER_PERIPH_PKG): $(SN_CLUSTER_PERIPH_TOP)
+$(SN_CLUSTER_PERIPH_TOP): $(SN_PERIPH_DIR)/snitch_cluster_peripheral_reg.hjson
+	@echo "[REGGEN] Generating peripheral regfile"
+	$(REGGEN) -r -t $(SN_PERIPH_DIR) $<
+
+# Bootrom rules
+$(SN_BOOTROM_DIR)/bootrom.elf $(SN_BOOTROM_DIR)/bootrom.dump $(SN_BOOTROM_DIR)/bootrom.bin $(SN_BOOTROM): $(SN_BOOTROM_DIR)/bootrom.S $(SN_BOOTROM_DIR)/bootrom.ld $(SN_BOOTROM_GEN) | $(SN_BOOTROM_DIR)
+	$(RISCV_CC) -mabi=ilp32d -march=rv32imafd -static -nostartfiles -fuse-ld=$(RISCV_LD) -L$(SN_ROOT)/sw/runtime -T$(SN_BOOTROM_DIR)/bootrom.ld $< -o $(SN_BOOTROM_DIR)/bootrom.elf
+	$(RISCV_OBJDUMP) -d $(SN_BOOTROM_DIR)/bootrom.elf > $(SN_BOOTROM_DIR)/bootrom.dump
+	$(RISCV_OBJCOPY) -j .text -O binary $(SN_BOOTROM_DIR)/bootrom.elf $(SN_BOOTROM_DIR)/bootrom.bin
+	$(SN_BOOTROM_GEN) --sv-module snitch_bootrom $(SN_BOOTROM_DIR)/bootrom.bin > $(SN_BOOTROM)
+
+# General RTL targets
+.PHONY: sn-rtl sn-clean-rtl
+
+sn-rtl: $(SN_GEN_RTL_SRCS)
+
+sn-clean-rtl:
+	rm -f $(SN_GEN_RTL_SRCS)
+
+$(SN_BOOTROM_DIR):
+	mkdir -p $@

--- a/target/common/vcs.mk
+++ b/target/common/vcs.mk
@@ -2,8 +2,41 @@
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
+#############
+# Variables #
+#############
+
+# Tools
+VCS_SEPP ?=
+VCS      ?= $(VCS_SEPP) vcs
+
+# VCS_BUILDDIR should be the same as the `DEFAULT : ./work-vcs`
+# in target/snitch_cluster/synopsys_sim.setup
+VCS_BENDER_FLAGS += $(COMMON_BENDER_FLAGS) $(COMMON_BENDER_SIM_FLAGS) -t vcs
+VCS_SOURCES       = $(shell $(BENDER) script flist-plus $(VCS_BENDER_FLAGS) | $(SED_SRCS))
+
+# Directories
+VCS_BUILDDIR = work-vcs
+
+# Flags
+VLOGAN_FLAGS := -assert svaext
+VLOGAN_FLAGS += -assert disable_cover
+VLOGAN_FLAGS += -full64
+VLOGAN_FLAGS += -kdb
+VLOGAN_FLAGS += -timescale=1ns/1ps
+VHDLAN_FLAGS := -full64
+VHDLAN_FLAGS += -kdb
+VCS_FLAGS    += -full64
+VCS_FLAGS    += -assert disable_cover
+VCS_FLAGS    += -override_timescale=1ns/1ps
+
+# Misc
 VCS_TOP_MODULE = tb_bin
 VCS_RTL_PREREQ_FILE = $(VCS_BUILDDIR)/$(VCS_TOP_MODULE).d
+
+#########
+# Rules #
+#########
 
 $(VCS_BUILDDIR):
 	mkdir -p $@
@@ -11,20 +44,23 @@ $(VCS_BUILDDIR):
 # Generate RTL prerequisites
 $(eval $(call gen_rtl_prerequisites,$(VCS_RTL_PREREQ_FILE),$(VCS_BUILDDIR),$(VCS_BENDER),$(VCS_TOP_MODULE),$(BIN_DIR)/$(TARGET).vcs))
 
-# Generation compilation script
+# Generate compilation script
 $(VCS_BUILDDIR)/compile.sh: $(BENDER_YML) $(BENDER_LOCK) | $(VCS_BUILDDIR)
-	$(BENDER) script vcs $(VCS_BENDER) --vlog-arg="$(VLOGAN_FLAGS)" --vcom-arg="$(VHDLAN_FLAGS)" > $@
+	$(BENDER) script vcs $(VCS_BENDER_FLAGS) --vlog-arg="$(VLOGAN_FLAGS)" --vcom-arg="$(VHDLAN_FLAGS)" > $@
 	chmod +x $@
 
 # Run compilation script and create VCS simulation binary
-$(BIN_DIR)/$(TARGET).vcs: $(VCS_BUILDDIR)/compile.sh $(TB_CC_SOURCES) $(RTL_CC_SOURCES) work/lib/libfesvr.a | $(BIN_DIR)
+$(SN_BIN_DIR)/$(TARGET).vcs: $(VCS_BUILDDIR)/compile.sh $(TB_CC_SOURCES) $(RTL_CC_SOURCES) work/lib/libfesvr.a | $(SN_BIN_DIR)
 	$(VCS_SEPP) $< > $(VCS_BUILDDIR)/compile.log
 	$(VCS) -Mlib=$(VCS_BUILDDIR) -Mdir=$(VCS_BUILDDIR) -o $@ -cc $(CC) -cpp $(CXX) \
-		-assert disable_cover -override_timescale=1ns/1ps -full64 $(VCS_TOP_MODULE) $(TB_CC_SOURCES) $(RTL_CC_SOURCES) \
+		$(VCS_FLAGS) $(VCS_TOP_MODULE) $(TB_CC_SOURCES) $(RTL_CC_SOURCES) \
 		-CFLAGS "$(TB_CC_FLAGS)" -LDFLAGS "-L$(FESVR)/lib" -lfesvr
 
+.PHONY: vcs clean-vcs
+
+vcs: $(SN_BIN_DIR)/$(TARGET).vcs
+
 # Clean all build directories and temporary files for VCS simulation
-.PHONY: clean-vcs
 clean-vcs: clean-work
 	rm -rf $(BIN_DIR)/$(TARGET).vcs $(VCS_BUILDDIR) vc_hdrs.h
 

--- a/target/common/verilator.mk
+++ b/target/common/verilator.mk
@@ -2,8 +2,49 @@
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
+#######################
+# Makefile invocation #
+#######################
+
+VLT_NUM_THREADS ?= 1
+VLT_JOBS        ?= $(shell nproc)
+
+#############
+# Variables #
+#############
+
+# Tools
+VERILATOR_SEPP ?=
+VLT            ?= $(VERILATOR_SEPP) verilator
+
+# Directories
+VLT_BUILDDIR = $(abspath work-vlt)
+VLT_FESVR    = $(VLT_BUILDDIR)/riscv-isa-sim
+
+# Flags
+VLT_BENDER_FLAGS += $(COMMON_BENDER_FLAGS) -t verilator -DASSERTS_OFF
+VLT_FLAGS += --timing
+VLT_FLAGS += --timescale 1ns/1ps
+VLT_FLAGS += --trace
+VLT_FLAGS += -Wno-BLKANDNBLK
+VLT_FLAGS += -Wno-LITENDIAN
+VLT_FLAGS += -Wno-CASEINCOMPLETE
+VLT_FLAGS += -Wno-CMPCONST
+VLT_FLAGS += -Wno-WIDTH
+VLT_FLAGS += -Wno-WIDTHCONCAT
+VLT_FLAGS += -Wno-UNSIGNED
+VLT_FLAGS += -Wno-UNOPTFLAT
+VLT_FLAGS += -Wno-fatal
+VLT_FLAGS += --unroll-count 1024
+VLT_FLAGS += --threads $(VLT_NUM_THREADS)
+
+# Misc
 VLT_TOP_MODULE = testharness
 VLT_RTL_PREREQ_FILE = $(VLT_BUILDDIR)/$(VLT_TOP_MODULE).d
+
+#########
+# Rules #
+#########
 
 $(VLT_BUILDDIR):
 	mkdir -p $@
@@ -11,30 +52,51 @@ $(VLT_BUILDDIR):
 # Generate RTL prerequisites
 $(eval $(call gen_rtl_prerequisites,$(VLT_RTL_PREREQ_FILE),$(VLT_BUILDDIR),$(VLT_BENDER),$(VLT_TOP_MODULE),$(BIN_DIR)/$(TARGET).vlt))
 
-# This target just redirects the verilator simulation binary.
-# On IIS machines, verilator needs to be built and run in
-# the oseda environment, which is why this is necessary.
-$(BIN_DIR)/$(TARGET).vlt: $(BIN_DIR)/$(TARGET)_bin.vlt
-	@echo "#!/bin/bash" > $@
-	@echo '$(VERILATOR_SEPP) $(realpath $<) $$(realpath $$1) $$2' >> $@
-	@chmod +x $@
+# Build fesvr seperately for verilator since this might use different compilers
+# and libraries than modelsim/vcs and
+# TODO(colluca): is this assumption still valid?
+$(VLT_FESVR)/${FESVR_VERSION}_unzip:
+	mkdir -p $(dir $@)
+	wget -O $(dir $@)/${FESVR_VERSION} https://github.com/riscv/riscv-isa-sim/tarball/${FESVR_VERSION}
+	tar xfm $(dir $@)${FESVR_VERSION} --strip-components=1 -C $(dir $@)
+	patch $(VLT_FESVR)/fesvr/context.h < patches/context.h.diff
+	touch $@
 
-$(BIN_DIR)/$(TARGET)_bin.vlt: $(TB_CC_SOURCES) $(VLT_CC_SOURCES) $(VLT_BUILDDIR)/lib/libfesvr.a | $(BIN_DIR)
-	$(VLT) $(shell $(BENDER) script verilator $(VLT_BENDER)) \
+$(VLT_BUILDDIR)/lib/libfesvr.a: $(VLT_FESVR)/${FESVR_VERSION}_unzip
+	cd $(dir $<)/ && ./configure --prefix `pwd` \
+        CC=${CC} CXX=${CXX} CFLAGS="${CFLAGS}" CXXFLAGS="${CXXFLAGS}" LDFLAGS="${LDFLAGS}"
+	$(MAKE) -C $(dir $<) install-config-hdrs install-hdrs libfesvr.a
+	mkdir -p $(dir $@)
+	cp $(dir $<)libfesvr.a $@
+
+# Generate and run compilation script, building the Verilator simulation binary
+$(SN_BIN_DIR)/$(TARGET)_bin.vlt: $(TB_CC_SOURCES) $(VLT_CC_SOURCES) $(VLT_BUILDDIR)/lib/libfesvr.a | $(SN_BIN_DIR) $(VLT_BUILDDIR)
+	$(VLT) $(shell $(BENDER) script verilator $(VLT_BENDER_FLAGS)) \
 		$(VLT_FLAGS) --Mdir $(VLT_BUILDDIR) \
 		-CFLAGS -std=c++20 \
 		-CFLAGS -I$(VLT_FESVR)/include \
 		-CFLAGS -I$(TB_DIR) \
 		-CFLAGS -I$(MKFILE_DIR)test \
 		-j $(VLT_JOBS) \
-		-o ../$@ --cc --exe --build --top-module $(VLT_TOP_MODULE) \
+		-o $@ --cc --exe --build --top-module $(VLT_TOP_MODULE) \
 		$(TB_CC_SOURCES) $(VLT_CC_SOURCES) $(VLT_BUILDDIR)/lib/libfesvr.a
 
-.PHONY: clean-vlt
-clean-vlt: clean-work
-	rm -rf $(BIN_DIR)/$(TARGET).vlt $(BIN_DIR)/$(TARGET)_bin.vlt $(VLT_BUILDDIR)
+# This target just redirects the verilator simulation binary.
+# On IIS machines, verilator needs to be built and run in
+# the oseda environment, which is why this is necessary.
+$(SN_BIN_DIR)/$(TARGET).vlt: $(SN_BIN_DIR)/$(TARGET)_bin.vlt | $(SN_BIN_DIR)
+	@echo "#!/bin/bash" > $@
+	@echo '$(VERILATOR_SEPP) $(realpath $<) $$(realpath $$1) $$2' >> $@
+	@chmod +x $@
 
-clean: clean-vlt
+.PHONY: verilator clean-verilator
+
+verilator: $(SN_BIN_DIR)/$(TARGET).vlt
+
+clean-verilator: clean-work
+	rm -rf $(SN_BIN_DIR)/$(TARGET).vlt $(SN_BIN_DIR)/$(TARGET)_bin.vlt $(VLT_BUILDDIR)
+
+clean: clean-verilator
 
 ifneq ($(filter-out clean%,$(MAKECMDGOALS)),)
 -include $(VLT_RTL_PREREQ_FILE)

--- a/target/common/vsim.mk
+++ b/target/common/vsim.mk
@@ -2,47 +2,111 @@
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
+#############
+# Variables #
+#############
+
+# Tools
+QUESTA_SEPP	?=
+VSIM        ?= $(QUESTA_SEPP) vsim
+VOPT        ?= $(QUESTA_SEPP) vopt
+VLOG        ?= $(QUESTA_SEPP) vlog
+VLIB        ?= $(QUESTA_SEPP) vlib
+
+# Sources
+VSIM_BENDER_FLAGS = $(COMMON_BENDER_FLAGS) $(COMMON_BENDER_SIM_FLAGS) -t vsim
+VSIM_SOURCES      = $(shell ${BENDER} script flist-plus $(VSIM_BENDER_FLAGS) | ${SED_SRCS})
+
+# Directories
+VSIM_BUILDDIR ?= $(SN_TARGET_DIR)/work-vsim
+
+# Flags
+VLOG_FLAGS += -64
+VLOG_FLAGS += -svinputport=compat
+VLOG_FLAGS += -override_timescale 1ns/1ps
+VLOG_FLAGS += -suppress 2583
+VLOG_FLAGS += -suppress 13314
+VLOG_FLAGS += -work $(VSIM_BUILDDIR)
+VOPT_FLAGS += -work $(VSIM_BUILDDIR)
+VSIM_FLAGS += -64
+VSIM_FLAGS += -work $(VSIM_BUILDDIR)
+VSIM_FLAGS += -t 1ps
+
+# DEBUG flag ensures visibility of all signals in the waveforms
+ifeq ($(DEBUG), ON)
+VSIM_FLAGS += -do "log -r /*; run -a"
+VOPT_FLAGS  = +acc
+else
+VSIM_FLAGS += -do "run -a"
+endif
+
+# PL_SIM flag selects between RTL or post-layout simulation
+ifeq ($(PL_SIM), 1)
+include $(SN_ROOT)/nonfree/gf12/modelsim/Makefrag
+COMMON_BENDER_FLAGS += -t postlayout
+VOPT_FLAGS += -modelsimini $(SN_ROOT)/nonfree/gf12/modelsim/modelsim.ini
+VOPT_FLAGS += +nospecify
+VOPT_FLAGS += $(GATE_LIBS)
+VSIM_FLAGS += -modelsimini $(SN_ROOT)/nonfree/gf12/modelsim/modelsim.ini
+VSIM_FLAGS += +nospecify
+endif
+
+# VCD_DUMP flag enables VCD dump generation
+ifeq ($(VCD_DUMP), 1)
+VSIM_FLAGS += -do "source $(ROOT)/nonfree/gf12/modelsim/vcd.tcl"
+else
+VSIM_FLAGS += -do "run -a"
+endif
+
+# Misc
 VSIM_TOP_MODULE = tb_bin
 VSIM_RTL_PREREQ_FILE = $(VSIM_BUILDDIR)/$(VSIM_TOP_MODULE).d
+
+#########
+# Rules #
+#########
 
 $(VSIM_BUILDDIR):
 	mkdir -p $@
 
 # Generate RTL prerequisites
-$(eval $(call gen_rtl_prerequisites,$(VSIM_RTL_PREREQ_FILE),$(VSIM_BUILDDIR),$(VSIM_BENDER),$(VSIM_TOP_MODULE),$(BIN_DIR)/$(TARGET).vsim))
+$(eval $(call gen_rtl_prerequisites,$(VSIM_RTL_PREREQ_FILE),$(VSIM_BUILDDIR),$(VSIM_BENDER),$(VSIM_TOP_MODULE),$(SN_BIN_DIR)/$(TARGET).vsim))
 
-# Generation compilation script
+# Generate compilation script
 $(VSIM_BUILDDIR)/compile.vsim.tcl: $(BENDER_YML) $(BENDER_LOCK) | $(VSIM_BUILDDIR)
 	$(VLIB) $(dir $@)
-	$(BENDER) script vsim $(VSIM_BENDER) --vlog-arg="$(VLOG_FLAGS) -work $(dir $@) " > $@
-	echo '$(VLOG) -work $(dir $@) $(TB_CC_SOURCES) $(RTL_CC_SOURCES) -vv -ccflags "$(TB_CC_FLAGS)"' >> $@
+	$(BENDER) script vsim $(VSIM_BENDER_FLAGS) --vlog-arg="$(VLOG_FLAGS) " > $@
+	echo '$(VLOG) -work $(VSIM_BUILDDIR) $(TB_CC_SOURCES) $(RTL_CC_SOURCES) -vv -ccflags "$(TB_CC_FLAGS)"' >> $@
 	echo 'return 0' >> $@
 
 # Run compilation script and create Questasim simulation binary
-$(BIN_DIR)/$(TARGET).vsim: $(VSIM_BUILDDIR)/compile.vsim.tcl $(TB_CC_SOURCES) $(RTL_CC_SOURCES) work/lib/libfesvr.a | $(BIN_DIR)
-	$(VSIM) -c -do "source $<; quit" | tee $(dir $<)vlog.log
-	@! grep -P "Errors: [1-9]*," $(dir $<)vlog.log
-	$(VOPT) $(VOPT_FLAGS) -work $(VSIM_BUILDDIR) $(VSIM_TOP_MODULE) -o $(VSIM_TOP_MODULE)_opt | tee $(dir $<)vopt.log
-	@! grep -P "Errors: [1-9]*," $(dir $<)vopt.log
+$(SN_BIN_DIR)/$(TARGET).vsim: $(VSIM_BUILDDIR)/compile.vsim.tcl $(TB_CC_SOURCES) $(RTL_CC_SOURCES) work/lib/libfesvr.a | $(SN_BIN_DIR)
+	$(VSIM) -c -do "source $<; quit" | tee $(dir $<)/vlog.log
+	@! grep -P "Errors: [1-9]*," $(dir $<)/vlog.log
+	$(VOPT) $(VOPT_FLAGS) -work $(dir $<) $(VSIM_TOP_MODULE) -o $(VSIM_TOP_MODULE)_opt | tee $(dir $<)/vopt.log
+	@! grep -P "Errors: [1-9]*," $(dir $<)/vopt.log
 	@echo "#!/bin/bash" > $@
 	@echo 'binary=$$(realpath $$1)' >> $@
 	@echo 'echo $$binary > .rtlbinary' >> $@
-	@echo '$(VSIM) +permissive $(VSIM_FLAGS) $$3 -work $(MKFILE_DIR)/$(VSIM_BUILDDIR) -c \
+	@echo '$(VSIM) +permissive $(VSIM_FLAGS) $$3 -c \
 				-quiet -ldflags "-Wl,-rpath,$(FESVR)/lib -L$(FESVR)/lib -lfesvr -lutil" \
 				$(VSIM_TOP_MODULE)_opt +permissive-off ++$$binary ++$$2' >> $@
 	@chmod +x $@
 	@echo "#!/bin/bash" > $@.gui
 	@echo 'binary=$$(realpath $$1)' >> $@.gui
 	@echo 'echo $$binary > .rtlbinary' >> $@.gui
-	@echo '$(VSIM) +permissive $(VSIM_FLAGS) -work $(MKFILE_DIR)/$(VSIM_BUILDDIR) \
+	@echo '$(VSIM) +permissive $(VSIM_FLAGS) \
 				-quiet -ldflags "-Wl,-rpath,$(FESVR)/lib -L$(FESVR)/lib -lfesvr -lutil" \
 				$(VSIM_TOP_MODULE)_opt +permissive-off ++$$binary ++$$2' >> $@.gui
 	@chmod +x $@.gui
 
+.PHONY: vsim clean-vsim
+
+vsim: $(SN_BIN_DIR)/$(TARGET).vsim
+
 # Clean all build directories and temporary files for Questasim simulation
-.PHONY: clean-vsim
 clean-vsim: clean-work
-	rm -rf $(BIN_DIR)/$(TARGET).vsim $(BIN_DIR)/$(TARGET).vsim.gui $(VSIM_BUILDDIR) vsim.wlf
+	rm -rf $(SN_BIN_DIR)/$(TARGET).vsim $(SN_BIN_DIR)/$(TARGET).vsim.gui $(VSIM_BUILDDIR) vsim.wlf
 
 clean: clean-vsim
 

--- a/target/snitch_cluster/.gitignore
+++ b/target/snitch_cluster/.gitignore
@@ -1,5 +1,5 @@
 /logs/
-/generated/
+/.generated/
 /bin/
 /cfg/lru.json
 /work/

--- a/target/snitch_cluster/Makefile
+++ b/target/snitch_cluster/Makefile
@@ -14,10 +14,9 @@ DEBUG ?= OFF
 # Override default config file
 CFG_OVERRIDE ?=
 
-.DEFAULT_GOAL := help
 .PHONY: all clean
 all: rtl sw
-clean: clean-rtl clean-work clean-logs clean-bender clean-generated
+clean: clean-rtl clean-sw clean-work clean-logs clean-bender clean-misc
 
 ##########
 # Common #
@@ -25,59 +24,31 @@ clean: clean-rtl clean-work clean-logs clean-bender clean-generated
 
 MKFILE_PATH := $(abspath $(lastword $(MAKEFILE_LIST)))
 MKFILE_DIR  := $(dir $(MKFILE_PATH))
-ROOT        := $(realpath ${MKFILE_DIR}../..)
-SNITCH_ROOT := $(ROOT)
+SN_ROOT     := $(realpath ${MKFILE_DIR}../..)
 
 TARGET = snitch_cluster
 
-include $(ROOT)/target/common/common.mk
-
-############
-# Programs #
-############
-
-REGGEN          ?= $(shell $(BENDER) path register_interface)/vendor/lowrisc_opentitan/util/regtool.py
-CLUSTER_GEN     ?= $(ROOT)/util/clustergen.py
-BOOTROM_GEN     ?= $(ROOT)/util/gen_bootrom.py
-CLUSTER_GEN_SRC ?= $(wildcard $(ROOT)/util/clustergen/*.py)
+include $(SN_ROOT)/target/common/common.mk
 
 #########################
 # Files and directories #
 #########################
 
-BIN_DIR           ?= bin
-GENERATED_DIR     ?= $(MKFILE_DIR)generated
-TEST_DIR          ?= $(MKFILE_DIR)test
-PERIPH_DIR        ?= $(ROOT)/hw/snitch_cluster/src/snitch_cluster_peripheral
+TB_DIR = $(SN_ROOT)/target/common/test
 
 # If the configuration file is overriden on the command-line (through
 # CFG_OVERRIDE) and this file differs from the least recently used
 # (LRU) config, all targets depending on the configuration file have
 # to be rebuilt. This file is used to express this condition as a
 # prerequisite for other rules.
-DEFAULT_CFG = cfg/default.json
-CFG         = cfg/lru.json
+DEFAULT_SN_CFG = cfg/default.json
+SN_CFG         = cfg/lru.json
 
-# Common dependency for all RTL simulators
-$(BIN_DIR):
-	mkdir -p $@
-
-#####################
-# Simulator options #
-#####################
+########
+# Misc #
+########
 
 COMMON_BENDER_FLAGS += -t snitch_cluster_wrapper
-
-QUESTA_64BIT = -64
-VLOG_64BIT   = -64
-
-VSIM_FLAGS += ${QUESTA_64BIT}
-
-VLOG_FLAGS += -svinputport=compat
-VLOG_FLAGS += -override_timescale 1ns/1ps
-VLOG_FLAGS += -suppress 2583
-VLOG_FLAGS += -suppress 13314
-VLOG_FLAGS += ${VLOG_64BIT}
 
 ###############
 # C testbench #
@@ -86,7 +57,7 @@ VLOG_FLAGS += ${VLOG_64BIT}
 TB_CC_SOURCES += \
 	${TB_DIR}/ipc.cc \
 	${TB_DIR}/common_lib.cc \
-	$(GENERATED_DIR)/bootdata.cc
+	$(SN_GEN_DIR)/bootdata.cc
 
 RTL_CC_SOURCES += ${TB_DIR}/rtl_lib.cc
 
@@ -104,8 +75,6 @@ TB_CC_FLAGS += \
 # Prerequisites #
 #################
 
-CLUSTER_GEN_PREREQ = ${CLUSTER_GEN} ${CLUSTER_GEN_SRC}
-
 # This target is always evaluated and creates a symlink to the least
 # recently used config file. Because it is a symlink, targets to which it is a
 # prerequisite will only be updated if the symlink target is newer than the
@@ -113,12 +82,12 @@ CLUSTER_GEN_PREREQ = ${CLUSTER_GEN} ${CLUSTER_GEN_SRC}
 # timestamp can be taken into account by using the `make -L` flag on the
 # command-line, however for simplicity we touch the symlink targets so it can
 # be used without.
-$(CFG): FORCE
+$(SN_CFG): FORCE
 	@# If the LRU config file doesn't exist, we use the default config.
 	@if [ ! -e "$@" ] ; then \
-		echo "Using default config file: $(DEFAULT_CFG)"; \
-		ln -s --relative $(DEFAULT_CFG) $@; \
-		touch $(DEFAULT_CFG); \
+		echo "Using default config file: $(DEFAULT_SN_CFG)"; \
+		ln -s --relative $(DEFAULT_SN_CFG) $@; \
+		touch $(DEFAULT_SN_CFG); \
 	fi
 	@# If a config file is provided on the command-line and the LRU
 	@# config file doesn't point to it already, then we make it point to it
@@ -139,122 +108,61 @@ FORCE:
 # Software #
 ############
 
-include $(ROOT)/target/snitch_cluster/sw.mk
+include $(SN_ROOT)/target/snitch_cluster/sw.mk
+
+.PHONY: sw clean-sw
+sw: sn-sw
+clean-sw: sn-clean-sw
 
 #######
 # RTL #
 #######
 
-GENERATED_RTL_SOURCES  = $(PERIPH_DIR)/snitch_cluster_peripheral_reg_top.sv
-GENERATED_RTL_SOURCES += $(PERIPH_DIR)/snitch_cluster_peripheral_reg_pkg.sv
-GENERATED_RTL_SOURCES += $(GENERATED_DIR)/snitch_cluster_wrapper.sv
-GENERATED_RTL_SOURCES += $(GENERATED_DIR)/snitch_cluster_pkg.sv
-GENERATED_RTL_SOURCES += $(TEST_DIR)/snitch_bootrom.sv
+include $(SN_ROOT)/target/common/rtl.mk
 
 .PHONY: rtl clean-rtl
+rtl: sn-rtl
+clean-rtl: sn-clean-rtl
 
-rtl: $(GENERATED_RTL_SOURCES)
+########
+# Misc #
+########
 
-clean-rtl:
-	rm -f $(GENERATED_RTL_SOURCES)
+SN_LINK_LD_TPL  = $(SN_ROOT)/hw/snitch_cluster/test/link.ld.tpl
+SN_BOOTDATA_TPL = $(SN_ROOT)/hw/snitch_cluster/test/bootdata.cc.tpl
 
-$(GENERATED_DIR):
-	mkdir -p $@
+$(eval $(call sn_cluster_gen_rule,$(SN_GEN_DIR)/link.ld,$(SN_LINK_LD_TPL)))
+$(eval $(call sn_cluster_gen_rule,$(SN_GEN_DIR)/bootdata.cc,$(SN_BOOTDATA_TPL)))
 
-CLUSTER_WRAPPER_TPL = $(ROOT)/hw/snitch_cluster/src/snitch_cluster_wrapper.sv.tpl
-CLUSTER_PKG_TPL     = $(ROOT)/hw/snitch_cluster/src/snitch_cluster_pkg.sv.tpl
-LINK_LD_TPL         = $(ROOT)/hw/snitch_cluster/test/link.ld.tpl
-BOOTDATA_TPL        = $(ROOT)/hw/snitch_cluster/test/bootdata.cc.tpl
+misc: $(SN_GEN_DIR)/link.ld $(SN_GEN_DIR)/bootdata.cc
+clean-misc:
+	rm -rf $(SN_GEN_DIR)/link.ld $(SN_GEN_DIR)/bootdata.cc
 
-# OCCAMYGEN artifacts
-$(eval $(call cluster_gen_rule,$(GENERATED_DIR)/snitch_cluster_wrapper.sv,$(CLUSTER_WRAPPER_TPL)))
-$(eval $(call cluster_gen_rule,$(GENERATED_DIR)/snitch_cluster_pkg.sv,$(CLUSTER_PKG_TPL)))
-$(eval $(call cluster_gen_rule,$(GENERATED_DIR)/link.ld,$(LINK_LD_TPL)))
-$(eval $(call cluster_gen_rule,$(GENERATED_DIR)/bootdata.cc,$(BOOTDATA_TPL)))
+##############
+# Simulators #
+##############
 
-# REGGEN regfile
-$(PERIPH_DIR)/snitch_cluster_peripheral_reg_pkg.sv: $(PERIPH_DIR)/snitch_cluster_peripheral_reg_top.sv
-$(PERIPH_DIR)/snitch_cluster_peripheral_reg_top.sv: $(PERIPH_DIR)/snitch_cluster_peripheral_reg.hjson
-	@echo "[REGGEN] Generating peripheral regfile"
-	$(REGGEN) -r -t $(PERIPH_DIR) $<
-
-# Bootrom
-.PHONY: bootrom
-bootrom: $(TEST_DIR)/snitch_bootrom.sv
-$(TEST_DIR)/bootrom.elf $(TEST_DIR)/bootrom.dump $(TEST_DIR)/bootrom.bin $(TEST_DIR)/snitch_bootrom.sv: $(TEST_DIR)/bootrom.S $(TEST_DIR)/bootrom.ld $(BOOTROM_GEN)
-	$(RISCV_CC) -mabi=ilp32d -march=rv32imafd -static -nostartfiles -fuse-ld=$(RISCV_LD) -Lsw/runtime -T$(TEST_DIR)/bootrom.ld $< -o $(TEST_DIR)/bootrom.elf
-	$(RISCV_OBJDUMP) -d $(TEST_DIR)/bootrom.elf > $(TEST_DIR)/bootrom.dump
-	$(RISCV_OBJCOPY) -j .text -O binary $(TEST_DIR)/bootrom.elf $(TEST_DIR)/bootrom.bin
-	$(BOOTROM_GEN) --sv-module snitch_bootrom $(TEST_DIR)/bootrom.bin > $(TEST_DIR)/snitch_bootrom.sv
-
-#############
-# Verilator #
-#############
-
-include $(ROOT)/target/common/verilator.mk
-
-############
-# Modelsim #
-############
-
-include $(ROOT)/target/common/vsim.mk
-
-#######
-# VCS #
-#######
-
-include $(ROOT)/target/common/vcs.mk
+include $(SN_ROOT)/target/common/verilator.mk
+include $(SN_ROOT)/target/common/vsim.mk
+include $(SN_ROOT)/target/common/vcs.mk
 
 #########
 # GVSOC #
 #########
 
-include $(ROOT)/target/common/gvsoc.mk
+include $(SN_ROOT)/target/common/gvsoc.mk
 
 ########
 # Util #
 ########
 
-.PHONY: clean-work clean-bender clean-logs help
+.PHONY: clean-work clean-bender clean-logs
 
 clean-work:
 	rm -rf work
 
 clean-bender:
-	rm -rf $(ROOT)/.bender/
+	rm -rf $(SN_ROOT)/.bender/
 
 clean-logs:
 	rm -rf $(LOGS_DIR)
-
-clean-generated:
-	rm -rf $(GENERATED_DIR)
-
-# Help command
-Blue=\033[1;34m
-Black=\033[0m
-help:
-	@echo -e "${Blue}Makefile Targets${Black} for the ${Blue}Snitch Cluster${Black}"
-	@echo -e "Use 'make <target>' where <target> is one of:"
-	@echo -e ""
-	@echo -e "${Blue}help           ${Black}Show an overview of all Makefile targets."
-	@echo -e ""
-	@echo -e "${Blue}$(BIN_DIR)/$(TARGET).vcs  ${Black}Build compilation script and compile all sources for VCS simulation."
-	@echo -e "${Blue}$(BIN_DIR)/$(TARGET).vlt  ${Black}Build compilation script and compile all sources for Verilator simulation."
-	@echo -e "${Blue}$(BIN_DIR)/$(TARGET).vsim ${Black}Build compilation script and compile all sources for Questasim simulation."
-	@echo -e ""
-	@echo -e "${Blue}sw               ${Black}Build all software."
-	@echo -e "${Blue}rtl              ${Black}Build all RTL."
-	@echo -e ""
-	@echo -e "${Blue}clean            ${Black}Clean everything except traces in logs directory."
-	@echo -e "${Blue}clean-bender     ${Black}Clean Bender dependencies."
-	@echo -e "${Blue}clean-rtl        ${Black}Clean all generated RTL sources."
-	@echo -e "${Blue}clean-sw         ${Black}Clean all software."
-	@echo -e "${Blue}clean-generated  ${Black}Delete all generated files in the generated directory."
-	@echo -e "${Blue}clean-logs       ${Black}Delete all traces in logs directory."
-	@echo -e "${Blue}clean-vcs        ${Black}Clean all build directories and temporary files for VCS simulation."
-	@echo -e "${Blue}clean-vlt        ${Black}Clean all build directories and temporary files for Verilator simulation."
-	@echo -e "${Blue}clean-vsim       ${Black}Clean all build directories and temporary files for Questasim simulation."
-	@echo -e ""
-	@echo -e "Additional useful targets from the included Makefrag:"
-	@echo -e "${Blue}traces           ${Black}Generate the better readable traces in .logs/trace_hart_<hart_id>.txt."
-	@echo -e "${Blue}annotate         ${Black}Annotate the better readable traces in .logs/trace_hart_<hart_id>.s with the source code related with the retired instructions."

--- a/target/snitch_cluster/sw.mk
+++ b/target/snitch_cluster/sw.mk
@@ -8,16 +8,16 @@
 # General targets #
 ###################
 
-.PHONY: sw clean-sw
+.PHONY: sn-sw sn-clean-sw
 
-all: sw
-clean: clean-sw
+sn-sw: sn-runtime sn-tests
+sn-clean-sw: sn-clean-runtime sn-clean-tests
 
 ####################
 # Platform headers #
 ####################
 
-SNRT_HAL_HDRS_DIR = $(ROOT)/target/snitch_cluster/sw/runtime/common
+SNRT_HAL_HDRS_DIR ?= $(SN_ROOT)/target/snitch_cluster/sw/runtime/common
 
 SNITCH_CLUSTER_CFG_H        = $(SNRT_HAL_HDRS_DIR)/snitch_cluster_cfg.h
 SNITCH_CLUSTER_ADDRMAP_H    = $(SNRT_HAL_HDRS_DIR)/snitch_cluster_addrmap.h
@@ -26,57 +26,65 @@ SNITCH_CLUSTER_PERIPHERAL_H = $(SNRT_HAL_HDRS_DIR)/snitch_cluster_peripheral.h
 SNRT_HAL_HDRS = $(SNITCH_CLUSTER_CFG_H) $(SNITCH_CLUSTER_ADDRMAP_H) $(SNITCH_CLUSTER_PERIPHERAL_H)
 
 # CLUSTERGEN headers
-$(eval $(call cluster_gen_rule,$(SNITCH_CLUSTER_CFG_H),$(SNITCH_CLUSTER_CFG_H).tpl))
-$(eval $(call cluster_gen_rule,$(SNITCH_CLUSTER_ADDRMAP_H),$(SNITCH_CLUSTER_ADDRMAP_H).tpl))
+$(eval $(call sn_cluster_gen_rule,$(SNITCH_CLUSTER_CFG_H),$(SNITCH_CLUSTER_CFG_H).tpl))
+$(eval $(call sn_cluster_gen_rule,$(SNITCH_CLUSTER_ADDRMAP_H),$(SNITCH_CLUSTER_ADDRMAP_H).tpl))
 
 # REGGEN headers
-$(SNITCH_CLUSTER_PERIPHERAL_H): $(ROOT)/hw/snitch_cluster/src/snitch_cluster_peripheral/snitch_cluster_peripheral_reg.hjson $(REGGEN)
+$(SNITCH_CLUSTER_PERIPHERAL_H): $(SN_ROOT)/hw/snitch_cluster/src/snitch_cluster_peripheral/snitch_cluster_peripheral_reg.hjson $(REGGEN)
 	$(call reggen_generate_header,$@,$<)
 
-.PHONY: clean-headers
-clean-sw: clean-headers
-clean-headers:
+.PHONY: sn-clean-headers
+sn-clean-sw: sn-clean-headers
+sn-clean-headers:
 	rm -f $(SNRT_HAL_HDRS)
 
 ##################
 # Subdirectories #
 ##################
 
-include sw/toolchain.mk
-include sw/runtime/runtime.mk
-include sw/tests/tests.mk
-include sw/riscv-tests/riscv-tests.mk
+include $(SN_ROOT)/target/snitch_cluster/sw/toolchain.mk
+include $(SN_ROOT)/target/snitch_cluster/sw/runtime/runtime.mk
+include $(SN_ROOT)/target/snitch_cluster/sw/tests/tests.mk
+include $(SN_ROOT)/target/snitch_cluster/sw/riscv-tests/riscv-tests.mk
 
-APPS  = sw/apps/nop
-APPS += sw/apps/blas/axpy
-APPS += sw/apps/blas/gemm
-APPS += sw/apps/blas/gemv
-APPS += sw/apps/blas/dot
-APPS += sw/apps/blas/syrk
-APPS += sw/apps/dnn/batchnorm
-APPS += sw/apps/dnn/conv2d
-APPS += sw/apps/dnn/fusedconv
-APPS += sw/apps/dnn/gelu
-APPS += sw/apps/dnn/layernorm
-APPS += sw/apps/dnn/maxpool
-APPS += sw/apps/dnn/softmax
-APPS += sw/apps/dnn/flashattention_2
-APPS += sw/apps/dnn/concat
-APPS += sw/apps/dnn/fused_concat_linear
-APPS += sw/apps/dnn/transpose
-APPS += sw/apps/montecarlo/pi_estimation
-APPS += sw/apps/atax
-APPS += sw/apps/correlation
-APPS += sw/apps/covariance
-APPS += sw/apps/doitgen
-APPS += sw/apps/kmeans
-APPS += sw/apps/exp
-APPS += sw/apps/log
-APPS += sw/apps/kbpcpa
-APPS += sw/apps/box3d1r
-APPS += sw/apps/j3d27pt
+SNRT_BUILD_APPS ?= ON
+
+ifeq ($(SNRT_BUILD_APPS), ON)
+SNRT_APPS  = sw/apps/nop
+SNRT_APPS += sw/apps/blas/axpy
+SNRT_APPS += sw/apps/blas/gemm
+SNRT_APPS += sw/apps/blas/gemv
+SNRT_APPS += sw/apps/blas/dot
+SNRT_APPS += sw/apps/blas/syrk
+SNRT_APPS += sw/apps/dnn/batchnorm
+SNRT_APPS += sw/apps/dnn/conv2d
+SNRT_APPS += sw/apps/dnn/fusedconv
+SNRT_APPS += sw/apps/dnn/gelu
+SNRT_APPS += sw/apps/dnn/layernorm
+SNRT_APPS += sw/apps/dnn/maxpool
+SNRT_APPS += sw/apps/dnn/softmax
+SNRT_APPS += sw/apps/dnn/flashattention_2
+SNRT_APPS += sw/apps/dnn/concat
+SNRT_APPS += sw/apps/dnn/fused_concat_linear
+SNRT_APPS += sw/apps/dnn/transpose
+SNRT_APPS += sw/apps/montecarlo/pi_estimation
+SNRT_APPS += sw/apps/atax
+SNRT_APPS += sw/apps/correlation
+SNRT_APPS += sw/apps/covariance
+SNRT_APPS += sw/apps/doitgen
+SNRT_APPS += sw/apps/kmeans
+SNRT_APPS += sw/apps/exp
+SNRT_APPS += sw/apps/log
+SNRT_APPS += sw/apps/kbpcpa
+SNRT_APPS += sw/apps/box3d1r
+SNRT_APPS += sw/apps/j3d27pt
 
 # Include Makefile from each app subdirectory
-$(foreach app,$(APPS), \
-	$(eval include $(app)/app.mk) \
+$(foreach app,$(SNRT_APPS), \
+	$(eval include $(SN_ROOT)/target/snitch_cluster/$(app)/app.mk) \
 )
+
+sn-sw: sn-apps
+sn-clean-sw: sn-clean-apps
+
+endif

--- a/target/snitch_cluster/sw/apps/atax/app.mk
+++ b/target/snitch_cluster/sw/apps/atax/app.mk
@@ -5,10 +5,10 @@
 # Luca Colagrande <colluca@iis.ee.ethz.ch>
 
 APP              := atax
-$(APP)_BUILD_DIR ?= $(ROOT)/target/snitch_cluster/sw/apps/$(APP)/build
-SRC_DIR          := $(ROOT)/sw/apps/$(APP)/src
+$(APP)_BUILD_DIR ?= $(SN_ROOT)/target/snitch_cluster/sw/apps/$(APP)/build
+SRC_DIR          := $(SN_ROOT)/sw/apps/$(APP)/src
 SRCS             := $(SRC_DIR)/main.c
-$(APP)_INCDIRS   := $(ROOT)/sw/blas
+$(APP)_INCDIRS   := $(SN_ROOT)/sw/blas
 
-include $(ROOT)/sw/apps/common.mk
-include $(ROOT)/target/snitch_cluster/sw/apps/common.mk
+include $(SN_ROOT)/sw/apps/common.mk
+include $(SN_ROOT)/target/snitch_cluster/sw/apps/common.mk

--- a/target/snitch_cluster/sw/apps/blas/axpy/app.mk
+++ b/target/snitch_cluster/sw/apps/blas/axpy/app.mk
@@ -5,9 +5,9 @@
 # Luca Colagrande <colluca@iis.ee.ethz.ch>
 
 APP              := axpy
-$(APP)_BUILD_DIR ?= $(ROOT)/target/snitch_cluster/sw/apps/blas/$(APP)/build
-SRC_DIR          := $(ROOT)/sw/blas/$(APP)/src
+$(APP)_BUILD_DIR ?= $(SN_ROOT)/target/snitch_cluster/sw/apps/blas/$(APP)/build
+SRC_DIR          := $(SN_ROOT)/sw/blas/$(APP)/src
 SRCS             := $(SRC_DIR)/main.c
 
-include $(ROOT)/sw/apps/common.mk
-include $(ROOT)/target/snitch_cluster/sw/apps/common.mk
+include $(SN_ROOT)/sw/apps/common.mk
+include $(SN_ROOT)/target/snitch_cluster/sw/apps/common.mk

--- a/target/snitch_cluster/sw/apps/blas/dot/app.mk
+++ b/target/snitch_cluster/sw/apps/blas/dot/app.mk
@@ -5,9 +5,9 @@
 # Luca Colagrande <colluca@iis.ee.ethz.ch>
 
 APP              := dot
-$(APP)_BUILD_DIR ?= $(ROOT)/target/snitch_cluster/sw/apps/blas/$(APP)/build
-SRC_DIR          := $(ROOT)/sw/blas/$(APP)/src
+$(APP)_BUILD_DIR ?= $(SN_ROOT)/target/snitch_cluster/sw/apps/blas/$(APP)/build
+SRC_DIR          := $(SN_ROOT)/sw/blas/$(APP)/src
 SRCS             := $(SRC_DIR)/main.c
 
-include $(ROOT)/sw/apps/common.mk
-include $(ROOT)/target/snitch_cluster/sw/apps/common.mk
+include $(SN_ROOT)/sw/apps/common.mk
+include $(SN_ROOT)/target/snitch_cluster/sw/apps/common.mk

--- a/target/snitch_cluster/sw/apps/blas/gemm/app.mk
+++ b/target/snitch_cluster/sw/apps/blas/gemm/app.mk
@@ -5,10 +5,10 @@
 # Luca Colagrande <colluca@iis.ee.ethz.ch>
 
 APP              := gemm
-$(APP)_BUILD_DIR ?= $(ROOT)/target/snitch_cluster/sw/apps/blas/$(APP)/build
-SRC_DIR          := $(ROOT)/sw/blas/$(APP)/src
+$(APP)_BUILD_DIR ?= $(SN_ROOT)/target/snitch_cluster/sw/apps/blas/$(APP)/build
+SRC_DIR          := $(SN_ROOT)/sw/blas/$(APP)/src
 SRCS             := $(SRC_DIR)/main.c
-$(APP)_INCDIRS   := $(ROOT)/sw/blas
+$(APP)_INCDIRS   := $(SN_ROOT)/sw/blas
 
-include $(ROOT)/sw/apps/common.mk
-include $(ROOT)/target/snitch_cluster/sw/apps/common.mk
+include $(SN_ROOT)/sw/apps/common.mk
+include $(SN_ROOT)/target/snitch_cluster/sw/apps/common.mk

--- a/target/snitch_cluster/sw/apps/blas/gemv/app.mk
+++ b/target/snitch_cluster/sw/apps/blas/gemv/app.mk
@@ -5,9 +5,9 @@
 # Luca Colagrande <colluca@iis.ee.ethz.ch>
 
 APP              := gemv
-$(APP)_BUILD_DIR ?= $(ROOT)/target/snitch_cluster/sw/apps/blas/$(APP)/build
-SRC_DIR          := $(ROOT)/sw/blas/$(APP)/src
+$(APP)_BUILD_DIR ?= $(SN_ROOT)/target/snitch_cluster/sw/apps/blas/$(APP)/build
+SRC_DIR          := $(SN_ROOT)/sw/blas/$(APP)/src
 SRCS             := $(SRC_DIR)/main.c
 
-include $(ROOT)/sw/apps/common.mk
-include $(ROOT)/target/snitch_cluster/sw/apps/common.mk
+include $(SN_ROOT)/sw/apps/common.mk
+include $(SN_ROOT)/target/snitch_cluster/sw/apps/common.mk

--- a/target/snitch_cluster/sw/apps/blas/syrk/app.mk
+++ b/target/snitch_cluster/sw/apps/blas/syrk/app.mk
@@ -5,10 +5,10 @@
 # Luca Colagrande <colluca@iis.ee.ethz.ch>
 
 APP              := syrk
-$(APP)_BUILD_DIR ?= $(ROOT)/target/snitch_cluster/sw/apps/blas/$(APP)/build
-SRC_DIR          := $(ROOT)/sw/blas/$(APP)/src
+$(APP)_BUILD_DIR ?= $(SN_ROOT)/target/snitch_cluster/sw/apps/blas/$(APP)/build
+SRC_DIR          := $(SN_ROOT)/sw/blas/$(APP)/src
 SRCS             := $(SRC_DIR)/main.c
-$(APP)_INCDIRS   := $(ROOT)/sw/blas
+$(APP)_INCDIRS   := $(SN_ROOT)/sw/blas
 
-include $(ROOT)/sw/apps/common.mk
-include $(ROOT)/target/snitch_cluster/sw/apps/common.mk
+include $(SN_ROOT)/sw/apps/common.mk
+include $(SN_ROOT)/target/snitch_cluster/sw/apps/common.mk

--- a/target/snitch_cluster/sw/apps/box3d1r/app.mk
+++ b/target/snitch_cluster/sw/apps/box3d1r/app.mk
@@ -5,9 +5,9 @@
 # Luca Colagrande <colluca@iis.ee.ethz.ch>
 
 APP              := box3d1r
-$(APP)_BUILD_DIR ?= $(ROOT)/target/snitch_cluster/sw/apps/$(APP)/build
-SRC_DIR          := $(ROOT)/sw/apps/$(APP)/src
+$(APP)_BUILD_DIR ?= $(SN_ROOT)/target/snitch_cluster/sw/apps/$(APP)/build
+SRC_DIR          := $(SN_ROOT)/sw/apps/$(APP)/src
 SRCS             := $(SRC_DIR)/main.c
 
-include $(ROOT)/sw/apps/common.mk
-include $(ROOT)/target/snitch_cluster/sw/apps/common.mk
+include $(SN_ROOT)/sw/apps/common.mk
+include $(SN_ROOT)/target/snitch_cluster/sw/apps/common.mk

--- a/target/snitch_cluster/sw/apps/common.mk
+++ b/target/snitch_cluster/sw/apps/common.mk
@@ -11,7 +11,7 @@
 $(APP)_HEADERS += $(SNRT_HAL_HDRS)
 
 $(APP)_INCDIRS += $(SNRT_INCDIRS)
-$(APP)_INCDIRS += $(SNITCH_ROOT)/sw/deps/riscv-opcodes
+$(APP)_INCDIRS += $(SN_ROOT)/sw/deps/riscv-opcodes
 
 $(APP)_RISCV_CFLAGS += $(RISCV_CFLAGS)
 $(APP)_RISCV_CFLAGS += $(addprefix -I,$($(APP)_INCDIRS))
@@ -21,16 +21,16 @@ $(APP)_LIBS += $(SNRT_LIB)
 $(APP)_LIBDIRS  = $(dir $($(APP)_LIBS))
 $(APP)_LIBNAMES = $(patsubst lib%,%,$(notdir $(basename $($(APP)_LIBS))))
 
-BASE_LD    = $(SNRT_DIR)/base.ld
-MEMORY_LD ?= $(SNITCH_ROOT)/target/snitch_cluster/sw/runtime/memory.ld
+SNRT_BASE_LD    = $(SNRT_DIR)/base.ld
+SNRT_MEMORY_LD ?= $(SN_ROOT)/target/snitch_cluster/sw/runtime/memory.ld
 
 $(APP)_RISCV_LDFLAGS += $(RISCV_LDFLAGS)
-$(APP)_RISCV_LDFLAGS += -L$(dir $(MEMORY_LD))
-$(APP)_RISCV_LDFLAGS += -T$(BASE_LD)
+$(APP)_RISCV_LDFLAGS += -L$(dir $(SNRT_MEMORY_LD))
+$(APP)_RISCV_LDFLAGS += -T$(SNRT_BASE_LD)
 $(APP)_RISCV_LDFLAGS += $(addprefix -L,$($(APP)_LIBDIRS))
 $(APP)_RISCV_LDFLAGS += $(addprefix -l,$($(APP)_LIBNAMES))
 
-LD_DEPS += $(MEMORY_LD) $(BASE_LD) $($(APP)_LIBS)
+SNRT_LD_DEPS += $(SNRT_MEMORY_LD) $(SNRT_BASE_LD) $($(APP)_LIBS)
 
 ###########
 # Outputs #
@@ -51,8 +51,8 @@ endif
 
 .PHONY: $(APP) clean-$(APP)
 
-sw: $(APP)
-clean-sw: clean-$(APP)
+sn-apps: $(APP)
+sn-clean-apps: clean-$(APP)
 
 $(APP): $(ALL_OUTPUTS)
 
@@ -74,12 +74,12 @@ $(ELF): RISCV_LDFLAGS := $($(APP)_RISCV_LDFLAGS)
 $(DEP): $(SRCS) | $($(APP)_BUILD_DIR) $($(APP)_HEADERS)
 	$(RISCV_CC) $(RISCV_CFLAGS) -MM -MT '$(ELF)' $< > $@
 
-$(ELF): $(SRCS) $(DEP) $(LD_DEPS) | $($(APP)_BUILD_DIR)
+$(ELF): $(SRCS) $(DEP) $(SNRT_LD_DEPS) | $($(APP)_BUILD_DIR)
 	$(RISCV_CC) $(RISCV_CFLAGS) $(RISCV_LDFLAGS) $(SRCS) -o $@
 
 $(DUMP): $(ELF) | $($(APP)_BUILD_DIR)
 	$(RISCV_OBJDUMP) $(RISCV_OBJDUMP_FLAGS) $< > $@
 
-ifneq ($(filter-out clean%,$(MAKECMDGOALS)),)
+ifneq ($(filter-out sn-clean%,$(MAKECMDGOALS)),)
 -include $(DEP)
 endif

--- a/target/snitch_cluster/sw/apps/correlation/app.mk
+++ b/target/snitch_cluster/sw/apps/correlation/app.mk
@@ -5,9 +5,9 @@
 # Luca Colagrande <colluca@iis.ee.ethz.ch>
 
 APP              := correlation
-$(APP)_BUILD_DIR ?= $(ROOT)/target/snitch_cluster/sw/apps/$(APP)/build
-SRC_DIR          := $(ROOT)/sw/apps/$(APP)/src
+$(APP)_BUILD_DIR ?= $(SN_ROOT)/target/snitch_cluster/sw/apps/$(APP)/build
+SRC_DIR          := $(SN_ROOT)/sw/apps/$(APP)/src
 SRCS             := $(SRC_DIR)/main.c
 
-include $(ROOT)/sw/apps/common.mk
-include $(ROOT)/target/snitch_cluster/sw/apps/common.mk
+include $(SN_ROOT)/sw/apps/common.mk
+include $(SN_ROOT)/target/snitch_cluster/sw/apps/common.mk

--- a/target/snitch_cluster/sw/apps/covariance/app.mk
+++ b/target/snitch_cluster/sw/apps/covariance/app.mk
@@ -5,10 +5,10 @@
 # Luca Colagrande <colluca@iis.ee.ethz.ch>
 
 APP              := covariance
-$(APP)_BUILD_DIR ?= $(ROOT)/target/snitch_cluster/sw/apps/$(APP)/build
-SRC_DIR          := $(ROOT)/sw/apps/$(APP)/src
+$(APP)_BUILD_DIR ?= $(SN_ROOT)/target/snitch_cluster/sw/apps/$(APP)/build
+SRC_DIR          := $(SN_ROOT)/sw/apps/$(APP)/src
 SRCS             := $(SRC_DIR)/main.c
-$(APP)_INCDIRS   := $(ROOT)/sw/blas/
+$(APP)_INCDIRS   := $(SN_ROOT)/sw/blas/
 
-include $(ROOT)/sw/apps/common.mk
-include $(ROOT)/target/snitch_cluster/sw/apps/common.mk
+include $(SN_ROOT)/sw/apps/common.mk
+include $(SN_ROOT)/target/snitch_cluster/sw/apps/common.mk

--- a/target/snitch_cluster/sw/apps/dnn/batchnorm/app.mk
+++ b/target/snitch_cluster/sw/apps/dnn/batchnorm/app.mk
@@ -5,9 +5,9 @@
 # Luca Colagrande <colluca@iis.ee.ethz.ch>
 
 APP              := batchnorm
-$(APP)_BUILD_DIR ?= $(ROOT)/target/snitch_cluster/sw/apps/dnn/$(APP)/build
-SRC_DIR          := $(ROOT)/sw/dnn/$(APP)/src
+$(APP)_BUILD_DIR ?= $(SN_ROOT)/target/snitch_cluster/sw/apps/dnn/$(APP)/build
+SRC_DIR          := $(SN_ROOT)/sw/dnn/$(APP)/src
 SRCS             := $(SRC_DIR)/main.c
 
-include $(ROOT)/sw/dnn/common.mk
-include $(ROOT)/target/snitch_cluster/sw/apps/common.mk
+include $(SN_ROOT)/sw/dnn/common.mk
+include $(SN_ROOT)/target/snitch_cluster/sw/apps/common.mk

--- a/target/snitch_cluster/sw/apps/dnn/concat/app.mk
+++ b/target/snitch_cluster/sw/apps/dnn/concat/app.mk
@@ -5,9 +5,9 @@
 # Luca Colagrande <colluca@iis.ee.ethz.ch>
 
 APP              := concat
-$(APP)_BUILD_DIR ?= $(ROOT)/target/snitch_cluster/sw/apps/dnn/$(APP)/build
-SRC_DIR          := $(ROOT)/sw/dnn/$(APP)/src
+$(APP)_BUILD_DIR ?= $(SN_ROOT)/target/snitch_cluster/sw/apps/dnn/$(APP)/build
+SRC_DIR          := $(SN_ROOT)/sw/dnn/$(APP)/src
 SRCS             := $(SRC_DIR)/main.c
 
-include $(ROOT)/sw/dnn/common.mk
-include $(ROOT)/target/snitch_cluster/sw/apps/common.mk
+include $(SN_ROOT)/sw/dnn/common.mk
+include $(SN_ROOT)/target/snitch_cluster/sw/apps/common.mk

--- a/target/snitch_cluster/sw/apps/dnn/conv2d/app.mk
+++ b/target/snitch_cluster/sw/apps/dnn/conv2d/app.mk
@@ -5,9 +5,9 @@
 # Luca Colagrande <colluca@iis.ee.ethz.ch>
 
 APP              := conv2d
-$(APP)_BUILD_DIR ?= $(ROOT)/target/snitch_cluster/sw/apps/dnn/$(APP)/build
-SRC_DIR          := $(ROOT)/sw/dnn/$(APP)/src
+$(APP)_BUILD_DIR ?= $(SN_ROOT)/target/snitch_cluster/sw/apps/dnn/$(APP)/build
+SRC_DIR          := $(SN_ROOT)/sw/dnn/$(APP)/src
 SRCS             := $(SRC_DIR)/main.c
 
-include $(ROOT)/sw/dnn/common.mk
-include $(ROOT)/target/snitch_cluster/sw/apps/common.mk
+include $(SN_ROOT)/sw/dnn/common.mk
+include $(SN_ROOT)/target/snitch_cluster/sw/apps/common.mk

--- a/target/snitch_cluster/sw/apps/dnn/flashattention_2/app.mk
+++ b/target/snitch_cluster/sw/apps/dnn/flashattention_2/app.mk
@@ -5,9 +5,9 @@
 # Luca Colagrande <colluca@iis.ee.ethz.ch>
 
 APP              := flashattention_2
-$(APP)_BUILD_DIR ?= $(ROOT)/target/snitch_cluster/sw/apps/dnn/$(APP)/build
-SRC_DIR          := $(ROOT)/sw/dnn/$(APP)/src
+$(APP)_BUILD_DIR ?= $(SN_ROOT)/target/snitch_cluster/sw/apps/dnn/$(APP)/build
+SRC_DIR          := $(SN_ROOT)/sw/dnn/$(APP)/src
 SRCS             := $(SRC_DIR)/main.c
 
-include $(ROOT)/sw/dnn/common.mk
-include $(ROOT)/target/snitch_cluster/sw/apps/common.mk
+include $(SN_ROOT)/sw/dnn/common.mk
+include $(SN_ROOT)/target/snitch_cluster/sw/apps/common.mk

--- a/target/snitch_cluster/sw/apps/dnn/fused_concat_linear/app.mk
+++ b/target/snitch_cluster/sw/apps/dnn/fused_concat_linear/app.mk
@@ -5,9 +5,9 @@
 # Luca Colagrande <colluca@iis.ee.ethz.ch>
 
 APP              := fused_concat_linear
-$(APP)_BUILD_DIR ?= $(ROOT)/target/snitch_cluster/sw/apps/dnn/$(APP)/build
-SRC_DIR          := $(ROOT)/sw/dnn/$(APP)/src
+$(APP)_BUILD_DIR ?= $(SN_ROOT)/target/snitch_cluster/sw/apps/dnn/$(APP)/build
+SRC_DIR          := $(SN_ROOT)/sw/dnn/$(APP)/src
 SRCS             := $(SRC_DIR)/main.c
 
-include $(ROOT)/sw/dnn/common.mk
-include $(ROOT)/target/snitch_cluster/sw/apps/common.mk
+include $(SN_ROOT)/sw/dnn/common.mk
+include $(SN_ROOT)/target/snitch_cluster/sw/apps/common.mk

--- a/target/snitch_cluster/sw/apps/dnn/fusedconv/app.mk
+++ b/target/snitch_cluster/sw/apps/dnn/fusedconv/app.mk
@@ -5,9 +5,9 @@
 # Luca Colagrande <colluca@iis.ee.ethz.ch>
 
 APP              := fusedconv
-$(APP)_BUILD_DIR ?= $(ROOT)/target/snitch_cluster/sw/apps/dnn/$(APP)/build
-SRC_DIR          := $(ROOT)/sw/dnn/$(APP)/src
+$(APP)_BUILD_DIR ?= $(SN_ROOT)/target/snitch_cluster/sw/apps/dnn/$(APP)/build
+SRC_DIR          := $(SN_ROOT)/sw/dnn/$(APP)/src
 SRCS             := $(SRC_DIR)/main.c
 
-include $(ROOT)/sw/dnn/common.mk
-include $(ROOT)/target/snitch_cluster/sw/apps/common.mk
+include $(SN_ROOT)/sw/dnn/common.mk
+include $(SN_ROOT)/target/snitch_cluster/sw/apps/common.mk

--- a/target/snitch_cluster/sw/apps/dnn/gelu/app.mk
+++ b/target/snitch_cluster/sw/apps/dnn/gelu/app.mk
@@ -5,9 +5,9 @@
 # Luca Colagrande <colluca@iis.ee.ethz.ch>
 
 APP              := gelu
-$(APP)_BUILD_DIR ?= $(ROOT)/target/snitch_cluster/sw/apps/dnn/$(APP)/build
-SRC_DIR          := $(ROOT)/sw/dnn/$(APP)/src
+$(APP)_BUILD_DIR ?= $(SN_ROOT)/target/snitch_cluster/sw/apps/dnn/$(APP)/build
+SRC_DIR          := $(SN_ROOT)/sw/dnn/$(APP)/src
 SRCS             := $(SRC_DIR)/main.c
 
-include $(ROOT)/sw/dnn/common.mk
-include $(ROOT)/target/snitch_cluster/sw/apps/common.mk
+include $(SN_ROOT)/sw/dnn/common.mk
+include $(SN_ROOT)/target/snitch_cluster/sw/apps/common.mk

--- a/target/snitch_cluster/sw/apps/dnn/layernorm/app.mk
+++ b/target/snitch_cluster/sw/apps/dnn/layernorm/app.mk
@@ -5,9 +5,9 @@
 # Luca Colagrande <colluca@iis.ee.ethz.ch>
 
 APP              := layernorm
-$(APP)_BUILD_DIR ?= $(ROOT)/target/snitch_cluster/sw/apps/dnn/$(APP)/build
-SRC_DIR          := $(ROOT)/sw/dnn/$(APP)/src
+$(APP)_BUILD_DIR ?= $(SN_ROOT)/target/snitch_cluster/sw/apps/dnn/$(APP)/build
+SRC_DIR          := $(SN_ROOT)/sw/dnn/$(APP)/src
 SRCS             := $(SRC_DIR)/main.c
 
-include $(ROOT)/sw/dnn/common.mk
-include $(ROOT)/target/snitch_cluster/sw/apps/common.mk
+include $(SN_ROOT)/sw/dnn/common.mk
+include $(SN_ROOT)/target/snitch_cluster/sw/apps/common.mk

--- a/target/snitch_cluster/sw/apps/dnn/maxpool/app.mk
+++ b/target/snitch_cluster/sw/apps/dnn/maxpool/app.mk
@@ -5,9 +5,9 @@
 # Luca Colagrande <colluca@iis.ee.ethz.ch>
 
 APP              := maxpool
-$(APP)_BUILD_DIR ?= $(ROOT)/target/snitch_cluster/sw/apps/dnn/$(APP)/build
-SRC_DIR          := $(ROOT)/sw/dnn/$(APP)/src
+$(APP)_BUILD_DIR ?= $(SN_ROOT)/target/snitch_cluster/sw/apps/dnn/$(APP)/build
+SRC_DIR          := $(SN_ROOT)/sw/dnn/$(APP)/src
 SRCS             := $(SRC_DIR)/main.c
 
-include $(ROOT)/sw/dnn/common.mk
-include $(ROOT)/target/snitch_cluster/sw/apps/common.mk
+include $(SN_ROOT)/sw/dnn/common.mk
+include $(SN_ROOT)/target/snitch_cluster/sw/apps/common.mk

--- a/target/snitch_cluster/sw/apps/dnn/softmax/app.mk
+++ b/target/snitch_cluster/sw/apps/dnn/softmax/app.mk
@@ -5,9 +5,9 @@
 # Luca Colagrande <colluca@iis.ee.ethz.ch>
 
 APP              := softmax
-$(APP)_BUILD_DIR ?= $(ROOT)/target/snitch_cluster/sw/apps/dnn/$(APP)/build
-SRC_DIR          := $(ROOT)/sw/dnn/$(APP)/src
+$(APP)_BUILD_DIR ?= $(SN_ROOT)/target/snitch_cluster/sw/apps/dnn/$(APP)/build
+SRC_DIR          := $(SN_ROOT)/sw/dnn/$(APP)/src
 SRCS             := $(SRC_DIR)/main.c
 
-include $(ROOT)/sw/dnn/common.mk
-include $(ROOT)/target/snitch_cluster/sw/apps/common.mk
+include $(SN_ROOT)/sw/dnn/common.mk
+include $(SN_ROOT)/target/snitch_cluster/sw/apps/common.mk

--- a/target/snitch_cluster/sw/apps/dnn/transpose/app.mk
+++ b/target/snitch_cluster/sw/apps/dnn/transpose/app.mk
@@ -5,9 +5,9 @@
 # Luca Colagrande <colluca@iis.ee.ethz.ch>
 
 APP              := transpose
-$(APP)_BUILD_DIR ?= $(ROOT)/target/snitch_cluster/sw/apps/dnn/$(APP)/build
-SRC_DIR          := $(ROOT)/sw/dnn/$(APP)/src
+$(APP)_BUILD_DIR ?= $(SN_ROOT)/target/snitch_cluster/sw/apps/dnn/$(APP)/build
+SRC_DIR          := $(SN_ROOT)/sw/dnn/$(APP)/src
 SRCS             := $(SRC_DIR)/main.c
 
-include $(ROOT)/sw/dnn/common.mk
-include $(ROOT)/target/snitch_cluster/sw/apps/common.mk
+include $(SN_ROOT)/sw/dnn/common.mk
+include $(SN_ROOT)/target/snitch_cluster/sw/apps/common.mk

--- a/target/snitch_cluster/sw/apps/doitgen/app.mk
+++ b/target/snitch_cluster/sw/apps/doitgen/app.mk
@@ -5,10 +5,10 @@
 # Luca Colagrande <colluca@iis.ee.ethz.ch>
 
 APP              := doitgen
-$(APP)_BUILD_DIR ?= $(ROOT)/target/snitch_cluster/sw/apps/$(APP)/build
-SRC_DIR          := $(ROOT)/sw/apps/$(APP)/src
+$(APP)_BUILD_DIR ?= $(SN_ROOT)/target/snitch_cluster/sw/apps/$(APP)/build
+SRC_DIR          := $(SN_ROOT)/sw/apps/$(APP)/src
 SRCS             := $(SRC_DIR)/main.c
-$(APP)_INCDIRS   := $(ROOT)/sw/blas/
+$(APP)_INCDIRS   := $(SN_ROOT)/sw/blas/
 
-include $(ROOT)/sw/apps/common.mk
-include $(ROOT)/target/snitch_cluster/sw/apps/common.mk
+include $(SN_ROOT)/sw/apps/common.mk
+include $(SN_ROOT)/target/snitch_cluster/sw/apps/common.mk

--- a/target/snitch_cluster/sw/apps/exp/app.mk
+++ b/target/snitch_cluster/sw/apps/exp/app.mk
@@ -5,7 +5,7 @@
 # Luca Colagrande <colluca@iis.ee.ethz.ch>
 
 APP              := exp
-SRCS             := $(ROOT)/sw/apps/$(APP)/main.c
-$(APP)_BUILD_DIR ?= $(ROOT)/target/snitch_cluster/sw/apps/$(APP)/build
+SRCS             := $(SN_ROOT)/sw/apps/$(APP)/main.c
+$(APP)_BUILD_DIR ?= $(SN_ROOT)/target/snitch_cluster/sw/apps/$(APP)/build
 
-include $(ROOT)/target/snitch_cluster/sw/apps/common.mk
+include $(SN_ROOT)/target/snitch_cluster/sw/apps/common.mk

--- a/target/snitch_cluster/sw/apps/j3d27pt/app.mk
+++ b/target/snitch_cluster/sw/apps/j3d27pt/app.mk
@@ -5,9 +5,9 @@
 # Luca Colagrande <colluca@iis.ee.ethz.ch>
 
 APP              := j3d27pt
-$(APP)_BUILD_DIR ?= $(ROOT)/target/snitch_cluster/sw/apps/$(APP)/build
-SRC_DIR          := $(ROOT)/sw/apps/$(APP)/src
+$(APP)_BUILD_DIR ?= $(SN_ROOT)/target/snitch_cluster/sw/apps/$(APP)/build
+SRC_DIR          := $(SN_ROOT)/sw/apps/$(APP)/src
 SRCS             := $(SRC_DIR)/main.c
 
-include $(ROOT)/sw/apps/common.mk
-include $(ROOT)/target/snitch_cluster/sw/apps/common.mk
+include $(SN_ROOT)/sw/apps/common.mk
+include $(SN_ROOT)/target/snitch_cluster/sw/apps/common.mk

--- a/target/snitch_cluster/sw/apps/kbpcpa/app.mk
+++ b/target/snitch_cluster/sw/apps/kbpcpa/app.mk
@@ -5,9 +5,9 @@
 # Luca Colagrande <colluca@iis.ee.ethz.ch>
 
 APP              := kbpcpa
-$(APP)_BUILD_DIR ?= $(ROOT)/target/snitch_cluster/sw/apps/$(APP)/build
-SRC_DIR          := $(ROOT)/sw/apps/$(APP)/src
+$(APP)_BUILD_DIR ?= $(SN_ROOT)/target/snitch_cluster/sw/apps/$(APP)/build
+SRC_DIR          := $(SN_ROOT)/sw/apps/$(APP)/src
 SRCS             := $(SRC_DIR)/main.c
 
-include $(ROOT)/sw/apps/common.mk
-include $(ROOT)/target/snitch_cluster/sw/apps/common.mk
+include $(SN_ROOT)/sw/apps/common.mk
+include $(SN_ROOT)/target/snitch_cluster/sw/apps/common.mk

--- a/target/snitch_cluster/sw/apps/kmeans/app.mk
+++ b/target/snitch_cluster/sw/apps/kmeans/app.mk
@@ -5,10 +5,10 @@
 # Luca Colagrande <colluca@iis.ee.ethz.ch>
 
 APP                 := kmeans
-$(APP)_BUILD_DIR    ?= $(ROOT)/target/snitch_cluster/sw/apps/$(APP)/build
-SRC_DIR             := $(ROOT)/sw/apps/$(APP)/src
+$(APP)_BUILD_DIR    ?= $(SN_ROOT)/target/snitch_cluster/sw/apps/$(APP)/build
+SRC_DIR             := $(SN_ROOT)/sw/apps/$(APP)/src
 SRCS                := $(SRC_DIR)/main.c
 $(APP)_DATAGEN_ARGS  = --no-gui
 
-include $(ROOT)/sw/apps/common.mk
-include $(ROOT)/target/snitch_cluster/sw/apps/common.mk
+include $(SN_ROOT)/sw/apps/common.mk
+include $(SN_ROOT)/target/snitch_cluster/sw/apps/common.mk

--- a/target/snitch_cluster/sw/apps/log/app.mk
+++ b/target/snitch_cluster/sw/apps/log/app.mk
@@ -5,7 +5,7 @@
 # Luca Colagrande <colluca@iis.ee.ethz.ch>
 
 APP              := log
-SRCS             := $(ROOT)/sw/apps/$(APP)/main.c
-$(APP)_BUILD_DIR ?= $(ROOT)/target/snitch_cluster/sw/apps/$(APP)/build
+SRCS             := $(SN_ROOT)/sw/apps/$(APP)/main.c
+$(APP)_BUILD_DIR ?= $(SN_ROOT)/target/snitch_cluster/sw/apps/$(APP)/build
 
-include $(ROOT)/target/snitch_cluster/sw/apps/common.mk
+include $(SN_ROOT)/target/snitch_cluster/sw/apps/common.mk

--- a/target/snitch_cluster/sw/apps/montecarlo/pi_estimation/app.mk
+++ b/target/snitch_cluster/sw/apps/montecarlo/pi_estimation/app.mk
@@ -4,12 +4,12 @@
 #
 # Luca Colagrande <colluca@iis.ee.ethz.ch>
 
-PI_ESTIMATION_DIR := $(ROOT)/sw/apps/montecarlo/pi_estimation
-PRNG_DIR          := $(ROOT)/sw/apps/prng
+PI_ESTIMATION_DIR := $(SN_ROOT)/sw/apps/montecarlo/pi_estimation
+PRNG_DIR          := $(SN_ROOT)/sw/apps/prng
 
 APP              := pi_estimation
 SRCS             := $(PI_ESTIMATION_DIR)/main.c
 $(APP)_INCDIRS   := $(PI_ESTIMATION_DIR) $(PRNG_DIR)
-$(APP)_BUILD_DIR ?= $(ROOT)/target/snitch_cluster/sw/apps/montecarlo/pi_estimation/build
+$(APP)_BUILD_DIR ?= $(SN_ROOT)/target/snitch_cluster/sw/apps/montecarlo/pi_estimation/build
 
-include $(ROOT)/target/snitch_cluster/sw/apps/common.mk
+include $(SN_ROOT)/target/snitch_cluster/sw/apps/common.mk

--- a/target/snitch_cluster/sw/apps/nop/app.mk
+++ b/target/snitch_cluster/sw/apps/nop/app.mk
@@ -5,7 +5,7 @@
 # Luca Colagrande <colluca@iis.ee.ethz.ch>
 
 APP              := nop
-SRCS             := $(ROOT)/target/snitch_cluster/sw/apps/$(APP)/src/main.c
-$(APP)_BUILD_DIR ?= $(ROOT)/target/snitch_cluster/sw/apps/$(APP)/build
+SRCS             := $(SN_ROOT)/target/snitch_cluster/sw/apps/$(APP)/src/main.c
+$(APP)_BUILD_DIR ?= $(SN_ROOT)/target/snitch_cluster/sw/apps/$(APP)/build
 
-include $(ROOT)/target/snitch_cluster/sw/apps/common.mk
+include $(SN_ROOT)/target/snitch_cluster/sw/apps/common.mk

--- a/target/snitch_cluster/sw/riscv-tests/riscv-tests.mk
+++ b/target/snitch_cluster/sw/riscv-tests/riscv-tests.mk
@@ -13,8 +13,8 @@
 # Test selection #
 ##################
 # Sources & destination
-RVT_SCRDIR := $(ROOT)/sw/deps/riscv-tests/isa
-RVT_BUILDDIR := $(ROOT)/target/snitch_cluster/sw/riscv-tests/build/
+SN_RVTESTS_SCRDIR    = $(SN_ROOT)/sw/deps/riscv-tests/isa
+SN_RVTESTS_BUILDDIR ?= $(SN_ROOT)/target/snitch_cluster/sw/riscv-tests/build/
 
 # Select the desired test cases
 # We ignore the following tests as we cannot build them with the snitch
@@ -30,19 +30,19 @@ RVT_BUILDDIR := $(ROOT)/target/snitch_cluster/sw/riscv-tests/build/
 # - rv32uzbc
 # - rv32uzbs
 
-include $(RVT_SCRDIR)/rv32ui/Makefrag
-# include $(RVT_SCRDIR)/rv32uc/Makefrag
-include $(RVT_SCRDIR)/rv32um/Makefrag
-include $(RVT_SCRDIR)/rv32ua/Makefrag
-include $(RVT_SCRDIR)/rv32uf/Makefrag
-include $(RVT_SCRDIR)/rv32ud/Makefrag
-# include $(RVT_SCRDIR)/rv32uzfh/Makefrag
-# include $(RVT_SCRDIR)/rv32uzba/Makefrag
-# include $(RVT_SCRDIR)/rv32uzbb/Makefrag
-# include $(RVT_SCRDIR)/rv32uzbc/Makefrag
-# include $(RVT_SCRDIR)/rv32uzbs/Makefrag
-# include $(RVT_SCRDIR)/rv32si/Makefrag
-# include $(RVT_SCRDIR)/rv32mi/Makefrag
+include $(SN_RVTESTS_SCRDIR)/rv32ui/Makefrag
+# include $(SN_RVTESTS_SCRDIR)/rv32uc/Makefrag
+include $(SN_RVTESTS_SCRDIR)/rv32um/Makefrag
+include $(SN_RVTESTS_SCRDIR)/rv32ua/Makefrag
+include $(SN_RVTESTS_SCRDIR)/rv32uf/Makefrag
+include $(SN_RVTESTS_SCRDIR)/rv32ud/Makefrag
+# include $(SN_RVTESTS_SCRDIR)/rv32uzfh/Makefrag
+# include $(SN_RVTESTS_SCRDIR)/rv32uzba/Makefrag
+# include $(SN_RVTESTS_SCRDIR)/rv32uzbb/Makefrag
+# include $(SN_RVTESTS_SCRDIR)/rv32uzbc/Makefrag
+# include $(SN_RVTESTS_SCRDIR)/rv32uzbs/Makefrag
+# include $(SN_RVTESTS_SCRDIR)/rv32si/Makefrag
+# include $(SN_RVTESTS_SCRDIR)/rv32mi/Makefrag
 
 ###################
 # Build variables #
@@ -60,21 +60,21 @@ RVT_RISCV_OBJDUMP_FLAGS += --disassemble-zeroes --section=.text --section=.text.
 #########
 # Rules #
 #########
-vpath %.S $(RVT_SCRDIR)
+vpath %.S $(SN_RVTESTS_SCRDIR)
 
 # Create the objdumps for each compiled program
 %.dump: %
-	$(RISCV_OBJDUMP) $(RVT_RISCV_OBJDUMP_FLAGS) $(RVT_BUILDDIR)$<.elf > $(RVT_BUILDDIR)$@
+	$(RISCV_OBJDUMP) $(RVT_RISCV_OBJDUMP_FLAGS) $(SN_RVTESTS_BUILDDIR)$<.elf > $(SN_RVTESTS_BUILDDIR)$@
 
 # Macro to compile each program
 define compile_template
 
-$$($(1)_p_tests): $(1)-p-%: $(1)/%.S | $(RVT_BUILDDIR)
-	$$(RISCV_CC) $$(RVT_RISCV_CFLAGS) -I$(RVT_SCRDIR)/../env/p -I$(RVT_SCRDIR)/macros/scalar -T$(RVT_SCRDIR)/../env/p/link.ld $$< -o $(RVT_BUILDDIR)$$@.elf
+$$($(1)_p_tests): $(1)-p-%: $(1)/%.S | $(SN_RVTESTS_BUILDDIR)
+	$$(RISCV_CC) $$(RVT_RISCV_CFLAGS) -I$(SN_RVTESTS_SCRDIR)/../env/p -I$(SN_RVTESTS_SCRDIR)/macros/scalar -T$(SN_RVTESTS_SCRDIR)/../env/p/link.ld $$< -o $(SN_RVTESTS_BUILDDIR)$$@.elf
 $(1)_tests += $$($(1)_p_tests)
 
 $$($(1)_v_tests): $(1)-v-%: $(1)/%.S
-	$$(RISCV_CC) $$(RVT_RISCV_CFLAGS) -DENTROPY=0x$$(shell echo \$$@ | md5sum | cut -c 1-7) -std=gnu99 -O2 -I$(RVT_SCRDIR)/../env/v -I$(RVT_SCRDIR)/macros/scalar -T$(RVT_SCRDIR)/../env/v/link.ld $(RVT_SCRDIR)/../env/v/entry.S $(RVT_SCRDIR)/../env/v/*.c $$< -o $(RVT_BUILDDIR)$$@.elf
+	$$(RISCV_CC) $$(RVT_RISCV_CFLAGS) -DENTROPY=0x$$(shell echo \$$@ | md5sum | cut -c 1-7) -std=gnu99 -O2 -I$(SN_RVTESTS_SCRDIR)/../env/v -I$(SN_RVTESTS_SCRDIR)/macros/scalar -T$(SN_RVTESTS_SCRDIR)/../env/v/link.ld $(SN_RVTESTS_SCRDIR)/../env/v/entry.S $(SN_RVTESTS_SCRDIR)/../env/v/*.c $$< -o $(SN_RVTESTS_BUILDDIR)$$@.elf
 $(1)_tests += $$($(1)_v_tests)
 
 $(1)_tests_dump = $$(addsuffix .dump, $$($(1)_tests))
@@ -109,18 +109,18 @@ $(eval $(call compile_template,rv32mi))
 
 tests_dump = $(addsuffix .dump, $(tests))
 
-junk += $(addprefix $(RVT_BUILDDIR),$(addsuffix .elf,$(tests))) $(addprefix $(RVT_BUILDDIR),$(tests_dump))
+junk += $(addprefix $(SN_RVTESTS_BUILDDIR),$(addsuffix .elf,$(tests))) $(addprefix $(SN_RVTESTS_BUILDDIR),$(tests_dump))
 
-$(RVT_BUILDDIR):
+$(SN_RVTESTS_BUILDDIR):
 	mkdir -p $@
 
 .PHONY: riscv-tests clean-riscv-tests
 
-riscv-tests: $(tests_dump) | $(RVT_BUILDDIR)
+riscv-tests: $(tests_dump) | $(SN_RVTESTS_BUILDDIR)
 
 clean-riscv-tests:
 	rm -rf $(junk)
 
 # Integrate into main Makefile flow
-sw: riscv-tests
-clean-sw: clean-riscv-tests
+sn-sw: riscv-tests
+sn-clean-sw: clean-riscv-tests

--- a/target/snitch_cluster/sw/runtime/runtime.mk
+++ b/target/snitch_cluster/sw/runtime/runtime.mk
@@ -8,10 +8,10 @@
 # Directories #
 ###############
 
-SNRT_DIR         = $(SNITCH_ROOT)/sw/snRuntime
-SNRT_TARGET_DIR ?= $(SNITCH_ROOT)/target/snitch_cluster/sw/runtime/rtl
-SNRT_BUILDDIR    = $(SNRT_TARGET_DIR)/build
-SNRT_SRCDIR      = $(SNRT_TARGET_DIR)/src
+SNRT_DIR         = $(SN_ROOT)/sw/snRuntime
+SNRT_TARGET_DIR ?= $(SN_ROOT)/target/snitch_cluster/sw/runtime/rtl
+SNRT_BUILDDIR   ?= $(SNRT_TARGET_DIR)/build
+SNRT_SRCDIR     ?= $(SNRT_TARGET_DIR)/src
 
 ###################
 # Build variables #
@@ -45,19 +45,15 @@ ifeq ($(DEBUG), ON)
 SNRT_OUTPUTS += $(SNRT_DUMP)
 endif
 
-
 #########
 # Rules #
 #########
 
-.PHONY: runtime clean-runtime
+.PHONY: sn-runtime sn-clean-runtime
 
-sw: runtime
-clean-sw: clean-runtime
+sn-runtime: $(SNRT_OUTPUTS)
 
-runtime: $(SNRT_OUTPUTS)
-
-clean-runtime:
+sn-clean-runtime:
 	rm -rf $(SNRT_BUILDDIR)
 
 $(SNRT_BUILDDIR):
@@ -77,6 +73,6 @@ $(SNRT_DUMP): $(SNRT_LIB) | $(SNRT_BUILDDIR)
 
 $(SNRT_DEPS): | $(SNRT_HAL_HDRS)
 
-ifneq ($(filter-out clean%,$(MAKECMDGOALS)),)
+ifneq ($(filter-out sn-clean%,$(MAKECMDGOALS)),)
 -include $(SNRT_DEPS)
 endif


### PR DESCRIPTION
Several changes to streamline integration in systems, tested in [Picobello](https://github.com/pulp-platform/picobello/pull/29).

Key features:
- Better separation of Make fragments: `vcs.mk`, `vsim.mk`, `verilator.mk`, `rtl.mk`
- Prefix Makefile variables with `SN_` and targets with `sn-` to prevent name collisions when included in systems

Note: this PR is only a first in this direction, a more complete and consistent implementation will be merged shortly with a second PR.