### PR TITLE
Prevent unaligned memory accesses

### DIFF
--- a/sw/snRuntime/src/alloc.h
+++ b/sw/snRuntime/src/alloc.h
@@ -67,6 +67,8 @@ inline void snrt_l1_update_next(void *next) {
 inline void *snrt_l3_alloc(size_t size) {
     snrt_allocator_t *alloc = snrt_l3_allocator();
 
+    size = ALIGN_UP(size, MIN_CHUNK_SIZE);
+    
     // TODO: L3 alloc size check
 
     void *ret = (void *)alloc->next;


### PR DESCRIPTION
Fixes unaligned memory access errors:
```
float *SLASHfc1SLASHGemm_output_0;
       SLASHfc1SLASHGemm_output_0 = (float *) snrt_l3_alloc(sizeof(float ) * (4));
...
SLASHfc1SLASHGemm_output_0[((2 * i) + j)] = o;
```
Error:
```
[1358000] -Info: snitch.sv:2934: TOP.testharness.i_snitch_cluster.i_cluster.gen_core[0].i_snitch_cc.i_snitch: [Misaligned Load/Store Core 0] PC: 000080000280 Data: 00252027 Addr: 8000c679
```