### PR TITLE
Make Snitch runtime compatible with C++

### DIFF
--- a/sw/snRuntime/src/alloc_v2.h
+++ b/sw/snRuntime/src/alloc_v2.h
@@ -83,7 +83,7 @@ inline void *snrt_l1_alloc_compute_core_local(size_t size,
                                               const size_t alignment) {
     snrt_l1_allocator_v2()->next =
         ALIGN_UP(snrt_l1_allocator_v2()->next, alignment);
-    void *retval = snrt_l1_next_v2() + size * snrt_cluster_core_idx();
+    void *retval = ((uint8_t*) snrt_l1_next_v2()) + size * snrt_cluster_core_idx();
     snrt_l1_allocator_v2()->next += size * snrt_cluster_compute_core_num();
     snrt_l1_alloc_check_bounds();
     return retval;

--- a/sw/snRuntime/src/dm.h
+++ b/sw/snRuntime/src/dm.h
@@ -210,7 +210,7 @@ inline void dm_main(void) {
                     if (__builtin_sdma_stat(DM_STATUS_BUSY) == 0) {
                         DM_PRINTF(50, "idle\n");
                         dm_p->stat_pvalid = 1;
-                        dm_p->stat_q = 0;
+                        dm_p->stat_q = (en_stat_t)0;
                     }
                     break;
                 case STAT_EXIT:
@@ -219,7 +219,7 @@ inline void dm_main(void) {
                 case STAT_READY:
                     DM_PRINTF(50, "ready\n");
                     dm_p->stat_pvalid = 1;
-                    dm_p->stat_q = 0;
+                    dm_p->stat_q = (en_stat_t)0;
                     break;
             }
         }

--- a/sw/snRuntime/src/dma.h
+++ b/sw/snRuntime/src/dma.h
@@ -390,7 +390,7 @@ inline void snrt_dma_stop_tracking() {
 inline void snrt_dma_memset(void *ptr, uint8_t value, uint32_t len) {
     // set first 64bytes to value
     // memset(ptr, value, 64);
-    uint8_t *p = ptr;
+    uint8_t *p = (uint8_t*)ptr;
     uint32_t nbytes = 64;
     while (nbytes--) {
         *p++ = value;
@@ -414,7 +414,7 @@ inline snrt_dma_txid_t snrt_dma_load_1d_tile(void *dst, void *src,
                                              size_t tile_idx, size_t tile_size,
                                              uint32_t prec) {
     size_t tile_nbytes = tile_size * prec;
-    return snrt_dma_start_1d(dst, src + tile_idx * tile_nbytes, tile_nbytes);
+    return snrt_dma_start_1d(dst, ((uint8_t*)src) + tile_idx * tile_nbytes, tile_nbytes);
 }
 
 /**
@@ -429,7 +429,7 @@ inline snrt_dma_txid_t snrt_dma_store_1d_tile(void *dst, void *src,
                                               size_t tile_idx, size_t tile_size,
                                               uint32_t prec) {
     size_t tile_nbytes = tile_size * prec;
-    return snrt_dma_start_1d(dst + tile_idx * tile_nbytes, src, tile_nbytes);
+    return snrt_dma_start_1d(((uint8_t*)dst) + tile_idx * tile_nbytes, src, tile_nbytes);
 }
 
 /**
@@ -457,7 +457,7 @@ inline snrt_dma_txid_t snrt_dma_load_2d_tile(
     src_offset *= prec;
     // Initiate transfer
     return snrt_dma_start_2d(dst,                  // dst
-                             src + src_offset,     // src
+                             ((uint8_t*)src) + src_offset,     // src
                              tile_x0_size * prec,  // size
                              tile_x0_size * prec,  // dst_stride
                              full_x0_size * prec,  // src_stride
@@ -489,7 +489,7 @@ inline snrt_dma_txid_t snrt_dma_store_2d_tile(
     dst_offset += tile_x1_idx * tile_x1_size * full_x0_size;
     dst_offset *= prec;
     // Initiate transfer
-    return snrt_dma_start_2d(dst + dst_offset,     // dst
+    return snrt_dma_start_2d(((uint8_t*)dst) + dst_offset,     // dst
                              src,                  // src
                              tile_x0_size * prec,  // size
                              full_x0_size * prec,  // dst_stride

--- a/sw/snRuntime/src/omp/eu.h
+++ b/sw/snRuntime/src/omp/eu.h
@@ -165,7 +165,7 @@ inline uint32_t eu_get_workers_in_wfi() {
 inline void eu_init(void) {
     if (snrt_cluster_core_idx() == 0) {
         // Allocate the eu struct in L1 for fast access
-        eu_p = snrt_l1_alloc(sizeof(eu_t));
+        eu_p = (eu_t*)snrt_l1_alloc(sizeof(eu_t));
         snrt_memset((void *)eu_p, 0, sizeof(eu_t));
         // store copy of eu_p on shared memory
         eu_p_global = eu_p;

--- a/sw/snRuntime/src/printf.h
+++ b/sw/snRuntime/src/printf.h
@@ -7,6 +7,14 @@
 // Use snrt_putchar for printf
 #define _putchar snrt_putchar
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 extern void snrt_putchar(char character);
+
+#ifdef __cplusplus
+} // extern "C"
+#endif
 
 #include "../../deps/printf/printf.h"

--- a/sw/snRuntime/src/ssr.h
+++ b/sw/snRuntime/src/ssr.h
@@ -67,7 +67,7 @@ enum snrt_ssr_dim {
 /**
  * @brief The SSR configuration registers.
  */
-enum snrt_ssr_reg {
+typedef enum snrt_ssr_reg {
     SNRT_SSR_REG_STATUS = 0,      /**< SSR status register */
     SNRT_SSR_REG_REPEAT = 1,      /**< SSR repeat register */
     SNRT_SSR_REG_BOUNDS = 2,      /**< SSR bounds register */
@@ -77,7 +77,7 @@ enum snrt_ssr_reg {
     SNRT_SSR_REG_RPTR_INDIR = 16, /**< SSSR indir. indices read ptr register */
     SNRT_SSR_REG_RPTR = 24,       /**< SSR read pointer register */
     SNRT_SSR_REG_WPTR = 28        /**< SSR write pointer register */
-};
+} snrt_ssr_reg_t;
 
 /**
  * @brief The size of the SSSR indirection indices.
@@ -160,9 +160,9 @@ inline void write_ssr_cfg(enum snrt_ssr_reg reg, uint32_t dm, uint32_t value) {
  */
 inline void snrt_ssr_loop_1d(enum snrt_ssr_dm dm, size_t b0, size_t s0) {
     --b0;
-    write_ssr_cfg(SNRT_SSR_REG_BOUNDS + 0, dm, b0);
+    write_ssr_cfg((snrt_ssr_reg_t)(SNRT_SSR_REG_BOUNDS + 0), dm, b0);
     size_t a = 0;
-    write_ssr_cfg(SNRT_SSR_REG_STRIDES + 0, dm, s0 - a);
+    write_ssr_cfg((snrt_ssr_reg_t)(SNRT_SSR_REG_STRIDES + 0), dm, s0 - a);
     a += s0 * b0;
 }
 
@@ -178,12 +178,12 @@ inline void snrt_ssr_loop_2d(enum snrt_ssr_dm dm, size_t b0, size_t b1,
                              size_t s0, size_t s1) {
     --b0;
     --b1;
-    write_ssr_cfg(SNRT_SSR_REG_BOUNDS + 0, dm, b0);
-    write_ssr_cfg(SNRT_SSR_REG_BOUNDS + 1, dm, b1);
+    write_ssr_cfg((snrt_ssr_reg_t)(SNRT_SSR_REG_BOUNDS + 0), dm, b0);
+    write_ssr_cfg((snrt_ssr_reg_t)(SNRT_SSR_REG_BOUNDS + 1), dm, b1);
     size_t a = 0;
-    write_ssr_cfg(SNRT_SSR_REG_STRIDES + 0, dm, s0 - a);
+    write_ssr_cfg((snrt_ssr_reg_t)(SNRT_SSR_REG_STRIDES + 0), dm, s0 - a);
     a += s0 * b0;
-    write_ssr_cfg(SNRT_SSR_REG_STRIDES + 1, dm, s1 - a);
+    write_ssr_cfg((snrt_ssr_reg_t)(SNRT_SSR_REG_STRIDES + 1), dm, s1 - a);
     a += s1 * b1;
 }
 
@@ -202,15 +202,15 @@ inline void snrt_ssr_loop_3d(enum snrt_ssr_dm dm, size_t b0, size_t b1,
     --b0;
     --b1;
     --b2;
-    write_ssr_cfg(SNRT_SSR_REG_BOUNDS + 0, dm, b0);
-    write_ssr_cfg(SNRT_SSR_REG_BOUNDS + 1, dm, b1);
-    write_ssr_cfg(SNRT_SSR_REG_BOUNDS + 2, dm, b2);
+    write_ssr_cfg((snrt_ssr_reg_t)(SNRT_SSR_REG_BOUNDS + 0), dm, b0);
+    write_ssr_cfg((snrt_ssr_reg_t)(SNRT_SSR_REG_BOUNDS + 1), dm, b1);
+    write_ssr_cfg((snrt_ssr_reg_t)(SNRT_SSR_REG_BOUNDS + 2), dm, b2);
     size_t a = 0;
-    write_ssr_cfg(SNRT_SSR_REG_STRIDES + 0, dm, s0 - a);
+    write_ssr_cfg((snrt_ssr_reg_t)(SNRT_SSR_REG_STRIDES + 0), dm, s0 - a);
     a += s0 * b0;
-    write_ssr_cfg(SNRT_SSR_REG_STRIDES + 1, dm, s1 - a);
+    write_ssr_cfg((snrt_ssr_reg_t)(SNRT_SSR_REG_STRIDES + 1), dm, s1 - a);
     a += s1 * b1;
-    write_ssr_cfg(SNRT_SSR_REG_STRIDES + 2, dm, s2 - a);
+    write_ssr_cfg((snrt_ssr_reg_t)(SNRT_SSR_REG_STRIDES + 2), dm, s2 - a);
     a += s2 * b2;
 }
 
@@ -233,18 +233,18 @@ inline void snrt_ssr_loop_4d(enum snrt_ssr_dm dm, size_t b0, size_t b1,
     --b1;
     --b2;
     --b3;
-    write_ssr_cfg(SNRT_SSR_REG_BOUNDS + 0, dm, b0);
-    write_ssr_cfg(SNRT_SSR_REG_BOUNDS + 1, dm, b1);
-    write_ssr_cfg(SNRT_SSR_REG_BOUNDS + 2, dm, b2);
-    write_ssr_cfg(SNRT_SSR_REG_BOUNDS + 3, dm, b3);
+    write_ssr_cfg((snrt_ssr_reg_t)(SNRT_SSR_REG_BOUNDS + 0), dm, b0);
+    write_ssr_cfg((snrt_ssr_reg_t)(SNRT_SSR_REG_BOUNDS + 1), dm, b1);
+    write_ssr_cfg((snrt_ssr_reg_t)(SNRT_SSR_REG_BOUNDS + 2), dm, b2);
+    write_ssr_cfg((snrt_ssr_reg_t)(SNRT_SSR_REG_BOUNDS + 3), dm, b3);
     size_t a = 0;
-    write_ssr_cfg(SNRT_SSR_REG_STRIDES + 0, dm, s0 - a);
+    write_ssr_cfg((snrt_ssr_reg_t)(SNRT_SSR_REG_STRIDES + 0), dm, s0 - a);
     a += s0 * b0;
-    write_ssr_cfg(SNRT_SSR_REG_STRIDES + 1, dm, s1 - a);
+    write_ssr_cfg((snrt_ssr_reg_t)(SNRT_SSR_REG_STRIDES + 1), dm, s1 - a);
     a += s1 * b1;
-    write_ssr_cfg(SNRT_SSR_REG_STRIDES + 2, dm, s2 - a);
+    write_ssr_cfg((snrt_ssr_reg_t)(SNRT_SSR_REG_STRIDES + 2), dm, s2 - a);
     a += s2 * b2;
-    write_ssr_cfg(SNRT_SSR_REG_STRIDES + 3, dm, s3 - a);
+    write_ssr_cfg((snrt_ssr_reg_t)(SNRT_SSR_REG_STRIDES + 3), dm, s3 - a);
     a += s3 * b3;
 }
 
@@ -265,7 +265,7 @@ inline void snrt_ssr_repeat(enum snrt_ssr_dm dm, size_t count) {
  */
 inline void snrt_ssr_read(enum snrt_ssr_dm dm, enum snrt_ssr_dim dim,
                           volatile void *ptr) {
-    write_ssr_cfg(SNRT_SSR_REG_RPTR + dim, dm, (uintptr_t)ptr);
+    write_ssr_cfg((snrt_ssr_reg_t)(SNRT_SSR_REG_RPTR + dim), dm, (uintptr_t)ptr);
 }
 
 /**
@@ -276,7 +276,7 @@ inline void snrt_ssr_read(enum snrt_ssr_dm dm, enum snrt_ssr_dim dim,
  */
 inline void snrt_ssr_write(enum snrt_ssr_dm dm, enum snrt_ssr_dim dim,
                            volatile void *ptr) {
-    write_ssr_cfg(SNRT_SSR_REG_WPTR + dim, dm, (uintptr_t)ptr);
+    write_ssr_cfg((snrt_ssr_reg_t)(SNRT_SSR_REG_WPTR + dim), dm, (uintptr_t)ptr);
 }
 
 /**

--- a/sw/snRuntime/src/sync.h
+++ b/sw/snRuntime/src/sync.h
@@ -221,7 +221,7 @@ inline void snrt_global_reduction_dma(double *dst_buffer, double *src_buffer,
             if (is_active && is_sender) {
                 if (!snrt_is_compute_core()) {
                     void *dst =
-                        (void *)dst_buffer - (1 << level) * SNRT_CLUSTER_OFFSET;
+                        (uint8_t *)dst_buffer - (1 << level) * SNRT_CLUSTER_OFFSET;
                     snrt_dma_start_1d(dst, src_buffer, len * sizeof(double));
                     snrt_dma_wait_all();
                 }


### PR DESCRIPTION
Fix compilation errors on inclusion of Snitch runtime headers into .cpp code by making type casting explicit and avoiding arithmetics on void* pointers.