### PR TITLE
sw: Ensure inline asm output register allocation in FPU fence

### DIFF
--- a/sw/snRuntime/src/ssr.h
+++ b/sw/snRuntime/src/ssr.h
@@ -37,7 +37,9 @@
  * @brief Synchronize the integer and float pipelines.
  */
 inline void snrt_fpu_fence() {
-    unsigned tmp;
+    // We should use volatile otherwise the compiler can mess things up
+    // especially if there are multiple asm block output variables.
+    unsigned volatile tmp;
     asm volatile(
         "fmv.x.w %0, fa0\n"
         "mv      %0, %0\n"


### PR DESCRIPTION
The FPU fence uses a dummy variable to synchronize on the FPU pipeline. This dummy variable is passed to an inline asm block as in/output. In case there are more than one in/output the compiler will allocate the dummy variable to the same register as any other in/output because the unused variable is optimized away. We can ensure a separate register by marking it as volatile.