### PR TITLE
test: Make bootdata accessible in C programs

### DIFF
--- a/hw/snitch_cluster/test/bootdata.cc.tpl
+++ b/hw/snitch_cluster/test/bootdata.cc.tpl
@@ -1,12 +1,13 @@
-// Copyright 2021 ETH Zurich and University of Bologna.
+// Copyright 2025 ETH Zurich and University of Bologna.
 // Solderpad Hardware License, Version 0.51, see LICENSE for details.
 // SPDX-License-Identifier: SHL-0.51
 
-#include <tb_lib.hh>
+#include "bootdata.h"
 
 namespace sim {
 
-const BootData BOOTDATA = {.boot_addr = ${hex(cfg['cluster']['boot_addr'])},
+// Allow other C sources to use BOOTDATA (ex. crt0s defined in other SDKs)
+extern "C" const BootData BOOTDATA = {.boot_addr = ${hex(cfg['cluster']['boot_addr'])},
                            .core_count = ${cfg['cluster']['nr_cores']},
                            .hartid_base = ${cfg['cluster']['cluster_base_hartid']},
                            .tcdm_start = ${hex(cfg['cluster']['cluster_base_addr'])},

--- a/target/common/test/bootdata.h
+++ b/target/common/test/bootdata.h
@@ -1,0 +1,20 @@
+// Copyright 2025 ETH Zurich and University of Bologna.
+// Solderpad Hardware License, Version 0.51, see LICENSE for details.
+// SPDX-License-Identifier: SHL-0.51
+
+#pragma once
+
+#include <inttypes.h>
+
+struct BootData {
+    uint32_t boot_addr;
+    uint32_t core_count;
+    uint32_t hartid_base;
+    uint32_t tcdm_start;
+    uint32_t tcdm_size;
+    uint32_t tcdm_offset;
+    uint64_t global_mem_start;
+    uint64_t global_mem_end;
+    uint32_t cluster_count;
+    uint32_t clint_base;
+};

--- a/target/common/test/sim.hh
+++ b/target/common/test/sim.hh
@@ -14,6 +14,7 @@
 #include <unordered_map>
 #include <vector>
 
+#include "bootdata.h"
 #include "ipc.hh"
 
 namespace sim {

--- a/target/common/test/tb_lib.hh
+++ b/target/common/test/tb_lib.hh
@@ -116,18 +116,6 @@ struct GlobalMemory {
 extern GlobalMemory MEM;
 
 // The boot data generated along with the system RTL.
-struct BootData {
-    uint32_t boot_addr;
-    uint32_t core_count;
-    uint32_t hartid_base;
-    uint32_t tcdm_start;
-    uint32_t tcdm_size;
-    uint32_t tcdm_offset;
-    uint64_t global_mem_start;
-    uint64_t global_mem_end;
-    uint32_t cluster_count;
-    uint32_t clint_base;
-};
-extern const BootData BOOTDATA;
+extern "C" const BootData BOOTDATA;
 
 }  // namespace sim


### PR DESCRIPTION
This is useful to build crt0 in external SDKs, or external bootroms in SoCs.