### PR TITLE
Expose multiple wide TCDM ports

### DIFF
--- a/hw/snitch_cluster/src/snitch_cluster.sv
+++ b/hw/snitch_cluster/src/snitch_cluster.sv
@@ -70,6 +70,8 @@ module snitch_cluster
   parameter int unsigned DMAReqFifoDepth    = 3,
   /// Number of DMA channels.
   parameter int unsigned DMANumChannels     = 1,
+  /// Number of exposed TCDM wide ports
+  parameter int unsigned NumExpWideTcdmPorts = 1,
   /// Width of a single icache line.
   parameter int unsigned ICacheLineWidth [NrHives] = '{default: 0},
   /// Number of icache lines per set.
@@ -823,7 +825,7 @@ module snitch_cluster
   );
 
   snitch_tcdm_interconnect #(
-    .NumInp (1),
+    .NumInp (NumExpWideTcdmPorts),
     .NumOut (NrSuperBanks),
     .NumHyperBanks (NrHyperBanks),
     .tcdm_req_t (tcdm_dma_req_t),

--- a/hw/snitch_cluster/src/snitch_cluster.sv
+++ b/hw/snitch_cluster/src/snitch_cluster.sv
@@ -225,62 +225,62 @@ module snitch_cluster
 ) (
   /// System clock. If `IsoCrossing` is enabled this port is the _fast_ clock.
   /// The slower, half-frequency clock, is derived internally.
-  input  logic                          clk_i,
+  input  logic                                    clk_i,
   /// Asynchronous active high reset. This signal is assumed to be _async_.
-  input  logic                          rst_ni,
+  input  logic                                    rst_ni,
   /// Per-core debug request signal. Asserting this signals puts the
   /// corresponding core into debug mode. This signal is assumed to be _async_.
-  input  logic [NrCores-1:0]            debug_req_i,
+  input  logic [NrCores-1:0]                      debug_req_i,
   /// Machine external interrupt pending. Usually those interrupts come from a
   /// platform-level interrupt controller. This signal is assumed to be _async_.
-  input  logic [NrCores-1:0]            meip_i,
+  input  logic [NrCores-1:0]                      meip_i,
   /// Machine timer interrupt pending. Usually those interrupts come from a
   /// core-local interrupt controller such as a timer/RTC. This signal is
   /// assumed to be _async_.
-  input  logic [NrCores-1:0]            mtip_i,
+  input  logic [NrCores-1:0]                      mtip_i,
   /// Core software interrupt pending. Usually those interrupts come from
   /// another core to facilitate inter-processor-interrupts. This signal is
   /// assumed to be _async_.
-  input  logic [NrCores-1:0]            msip_i,
+  input  logic [NrCores-1:0]                      msip_i,
   // External interrupt pending.
-  input  logic [NrCores-1:0]            mxip_i,
+  input  logic [NrCores-1:0]                      mxip_i,
   /// First hartid of the cluster. Cores of a cluster are monotonically
   /// increasing without a gap, i.e., a cluster with 8 cores and a
   /// `hart_base_id_i` of 5 get the hartids 5 - 12.
-  input  logic [9:0]                    hart_base_id_i,
+  input  logic [9:0]                              hart_base_id_i,
   /// Base address of cluster. TCDM and cluster peripheral location are derived from
   /// it. This signal is pseudo-static.
-  input  logic [PhysicalAddrWidth-1:0]  cluster_base_addr_i,
+  input  logic [PhysicalAddrWidth-1:0]            cluster_base_addr_i,
   /// Configuration inputs for the memory cuts used in implementation.
   /// These signals are pseudo-static.
-  input  sram_cfgs_t                    sram_cfgs_i,
+  input  sram_cfgs_t                              sram_cfgs_i,
   /// Bypass half-frequency clock. (`d2` = divide-by-two). This signal is
   /// pseudo-static.
-  input  logic                          clk_d2_bypass_i,
+  input  logic                                    clk_d2_bypass_i,
   /// AXI Core cluster in-port.
-  input  narrow_in_req_t                narrow_in_req_i,
-  output narrow_in_resp_t               narrow_in_resp_o,
+  input  narrow_in_req_t                          narrow_in_req_i,
+  output narrow_in_resp_t                         narrow_in_resp_o,
   /// AXI Core cluster out-port.
-  output narrow_out_req_t               narrow_out_req_o,
-  input  narrow_out_resp_t              narrow_out_resp_i,
+  output narrow_out_req_t                         narrow_out_req_o,
+  input  narrow_out_resp_t                        narrow_out_resp_i,
   /// AXI DMA cluster out-port. Usually wider than the cluster ports so that the
   /// DMA engine can efficiently transfer bulk of data.
-  output wide_out_req_t                 wide_out_req_o,
-  input  wide_out_resp_t                wide_out_resp_i,
+  output wide_out_req_t                           wide_out_req_o,
+  input  wide_out_resp_t                          wide_out_resp_i,
   /// AXI DMA cluster in-port.
-  input  wide_in_req_t                  wide_in_req_i,
-  output wide_in_resp_t                 wide_in_resp_o,
+  input  wide_in_req_t                            wide_in_req_i,
+  output wide_in_resp_t                           wide_in_resp_o,
   // An additional AXI Core cluster out-port, used e.g. to connect
   // to the configuration interface of an external accelerator.
   // Compared to the `narrow_out` interface, the address space of
   // this port extends the cluster address space. We refer to the prior
   // as an external AXI plug, and to this as an externally-exposed
   // internal AXI plug.
-  output narrow_out_req_t               narrow_ext_req_o,
-  input  narrow_out_resp_t              narrow_ext_resp_i,
+  output narrow_out_req_t                         narrow_ext_req_o,
+  input  narrow_out_resp_t                        narrow_ext_resp_i,
   // External TCDM ports
-  input  tcdm_dma_req_t                 tcdm_ext_req_i,
-  output tcdm_dma_rsp_t                 tcdm_ext_resp_o
+  input  tcdm_dma_req_t [NumExpWideTcdmPorts-1:0] tcdm_ext_req_i,
+  output tcdm_dma_rsp_t [NumExpWideTcdmPorts-1:0] tcdm_ext_resp_o
 );
   // ---------
   // Constants

--- a/hw/snitch_cluster/src/snitch_cluster_wrapper.sv.tpl
+++ b/hw/snitch_cluster/src/snitch_cluster_wrapper.sv.tpl
@@ -99,6 +99,11 @@ module ${cfg['cluster']['name']}_wrapper (
     .DMANumAxInFlight (${cfg['cluster']['dma_axi_req_fifo_depth']}),
     .DMAReqFifoDepth (${cfg['cluster']['dma_req_fifo_depth']}),
     .DMANumChannels (${cfg['cluster']['dma_nr_channels']}),
+  % if cfg['cluster']['num_exposed_wide_tcdm_ports']==0:
+    .NumExpWideTcdmPorts (1),
+  % else:
+    .NumExpWideTcdmPorts (${cfg['cluster']['num_exposed_wide_tcdm_ports']}),
+  % endif
     .ICacheLineWidth (${cfg['cluster']['name']}_pkg::ICacheLineWidth),
     .ICacheLineCount (${cfg['cluster']['name']}_pkg::ICacheLineCount),
     .ICacheWays (${cfg['cluster']['name']}_pkg::ICacheWays),
@@ -204,11 +209,11 @@ module ${cfg['cluster']['name']}_wrapper (
     .narrow_ext_req_o (narrow_ext_req_o),
     .narrow_ext_resp_i (${cfg['cluster']['name']}_pkg::narrow_out_resp_t'('0)),
 % endif
-% if cfg['cluster']['wide_tcdm_port_expose']:
-    .tcdm_ext_req_i (tcdm_ext_req_i),
+% if cfg['cluster']['num_exposed_wide_tcdm_ports']==0:
+    .tcdm_ext_req_i (${cfg['cluster']['name']}_pkg::tcdm_dma_req_t'('0)),
     .tcdm_ext_resp_o (tcdm_ext_resp_o),
 % else:
-    .tcdm_ext_req_i (${cfg['cluster']['name']}_pkg::tcdm_dma_req_t'('0)),
+    .tcdm_ext_req_i (tcdm_ext_req_i),
     .tcdm_ext_resp_o (tcdm_ext_resp_o),
 % endif
     .narrow_in_req_i,

--- a/hw/snitch_cluster/src/snitch_cluster_wrapper.sv.tpl
+++ b/hw/snitch_cluster/src/snitch_cluster_wrapper.sv.tpl
@@ -50,8 +50,8 @@ module ${cfg['cluster']['name']}_wrapper (
   output ${cfg['cluster']['name']}_pkg::wide_in_resp_t      wide_in_resp_o,
   output ${cfg['cluster']['name']}_pkg::narrow_out_req_t    narrow_ext_req_o,
   input  ${cfg['cluster']['name']}_pkg::narrow_out_resp_t   narrow_ext_resp_i,
-  input  ${cfg['cluster']['name']}_pkg::tcdm_dma_req_t      tcdm_ext_req_i,
-  output ${cfg['cluster']['name']}_pkg::tcdm_dma_rsp_t      tcdm_ext_resp_o
+  input  ${cfg['cluster']['name']}_pkg::tcdm_dma_req_t [${cfg['cluster']['num_exposed_wide_tcdm_ports']-1 if cfg['cluster']['num_exposed_wide_tcdm_ports']!=0 else cfg['cluster']['num_exposed_wide_tcdm_ports']}:0] tcdm_ext_req_i,
+  output ${cfg['cluster']['name']}_pkg::tcdm_dma_rsp_t [${cfg['cluster']['num_exposed_wide_tcdm_ports']-1 if cfg['cluster']['num_exposed_wide_tcdm_ports']!=0 else cfg['cluster']['num_exposed_wide_tcdm_ports']}:0] tcdm_ext_resp_o
 );
 
   localparam int unsigned NumIntOutstandingLoads [${cfg['cluster']['nr_cores']}] = '{${core_cfg('num_int_outstanding_loads')}};
@@ -211,11 +211,10 @@ module ${cfg['cluster']['name']}_wrapper (
 % endif
 % if cfg['cluster']['num_exposed_wide_tcdm_ports']==0:
     .tcdm_ext_req_i (${cfg['cluster']['name']}_pkg::tcdm_dma_req_t'('0)),
-    .tcdm_ext_resp_o (tcdm_ext_resp_o),
 % else:
     .tcdm_ext_req_i (tcdm_ext_req_i),
-    .tcdm_ext_resp_o (tcdm_ext_resp_o),
 % endif
+    .tcdm_ext_resp_o (tcdm_ext_resp_o),
     .narrow_in_req_i,
     .narrow_in_resp_o,
     .narrow_out_req_o,

--- a/hw/snitch_cluster/src/snitch_cluster_wrapper.sv.tpl
+++ b/hw/snitch_cluster/src/snitch_cluster_wrapper.sv.tpl
@@ -28,6 +28,12 @@ ${int(getattr(c['isa_parsed'], isa))}\
   % endfor
 </%def>\
 
+<%
+  actual_num_exposed_wide_tcdm_ports = cfg['cluster']['num_exposed_wide_tcdm_ports']
+  if actual_num_exposed_wide_tcdm_ports == 0:
+    actual_num_exposed_wide_tcdm_ports += 1
+%>
+
 module ${cfg['cluster']['name']}_wrapper (
   input  logic                                   clk_i,
   input  logic                                   rst_ni,
@@ -50,8 +56,8 @@ module ${cfg['cluster']['name']}_wrapper (
   output ${cfg['cluster']['name']}_pkg::wide_in_resp_t      wide_in_resp_o,
   output ${cfg['cluster']['name']}_pkg::narrow_out_req_t    narrow_ext_req_o,
   input  ${cfg['cluster']['name']}_pkg::narrow_out_resp_t   narrow_ext_resp_i,
-  input  ${cfg['cluster']['name']}_pkg::tcdm_dma_req_t [${cfg['cluster']['num_exposed_wide_tcdm_ports']-1 if cfg['cluster']['num_exposed_wide_tcdm_ports']!=0 else cfg['cluster']['num_exposed_wide_tcdm_ports']}:0] tcdm_ext_req_i,
-  output ${cfg['cluster']['name']}_pkg::tcdm_dma_rsp_t [${cfg['cluster']['num_exposed_wide_tcdm_ports']-1 if cfg['cluster']['num_exposed_wide_tcdm_ports']!=0 else cfg['cluster']['num_exposed_wide_tcdm_ports']}:0] tcdm_ext_resp_o
+  input  ${cfg['cluster']['name']}_pkg::tcdm_dma_req_t [${actual_num_exposed_wide_tcdm_ports}-1:0] tcdm_ext_req_i,
+  output ${cfg['cluster']['name']}_pkg::tcdm_dma_rsp_t [${actual_num_exposed_wide_tcdm_ports}-1:0] tcdm_ext_resp_o
 );
 
   localparam int unsigned NumIntOutstandingLoads [${cfg['cluster']['nr_cores']}] = '{${core_cfg('num_int_outstanding_loads')}};
@@ -99,11 +105,7 @@ module ${cfg['cluster']['name']}_wrapper (
     .DMANumAxInFlight (${cfg['cluster']['dma_axi_req_fifo_depth']}),
     .DMAReqFifoDepth (${cfg['cluster']['dma_req_fifo_depth']}),
     .DMANumChannels (${cfg['cluster']['dma_nr_channels']}),
-  % if cfg['cluster']['num_exposed_wide_tcdm_ports']==0:
-    .NumExpWideTcdmPorts (1),
-  % else:
-    .NumExpWideTcdmPorts (${cfg['cluster']['num_exposed_wide_tcdm_ports']}),
-  % endif
+    .NumExpWideTcdmPorts (${actual_num_exposed_wide_tcdm_ports}),
     .ICacheLineWidth (${cfg['cluster']['name']}_pkg::ICacheLineWidth),
     .ICacheLineCount (${cfg['cluster']['name']}_pkg::ICacheLineCount),
     .ICacheWays (${cfg['cluster']['name']}_pkg::ICacheWays),

--- a/util/clustergen/schema/snitch_cluster.schema.json
+++ b/util/clustergen/schema/snitch_cluster.schema.json
@@ -175,7 +175,7 @@
                     "type": "number",
                     "description": "Width of the cluster's atomics ID.",
                     "default": 1
-                },  
+                },
                 "enable_multicast": {
                     "type": "boolean",
                     "description": "Whether to enable multicast in the cluster.",
@@ -231,10 +231,10 @@
                     "description": "Whether to expose memory cut configuration inputs for implementation",
                     "default": false
                 },
-                "wide_tcdm_port_expose": {
-                    "type": "boolean",
-                    "description": "Whether to expose a wide port into the TCDM at the cluster interface. Used to provide external masters, such as accelerators, with wide access to the TCDM.",
-                    "default": false
+                "num_exposed_wide_tcdm_ports": {
+                    "type": "number",
+                    "description": "Number of exposed wide ports into the TCDM at the cluster interface. Used to provide external masters, such as accelerators, with wide access to the TCDM.",
+                    "default": 0
                 },
                 "narrow_axi_port_expose": {
                     "type": "boolean",


### PR DESCRIPTION
This PR enables support for the exposure of multiple wide TCDM ports, useful if one wants to use multiple external accelerators at the same time.