### PR TITLE
ci: exclude markdown files from triggering full regression test suite

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,10 @@
 # Pull requests from forks cannot deploy the Docker container due to missing
 # secrets, thus we only enable this workflow on push triggers.
 name: ci
-on: [push]
+on:
+  push:
+    paths-ignore:
+      - '**/*.md'
 
 env:
   FORCE_COLOR: 1


### PR DESCRIPTION
### Change Summary
Currently, the `ci` workflow will run even when a push changes **only markdown files** (e.g., README.md).

With these changes, a push that changes *only* markdown files will not trigger the workflow, thus **speeding up the project's CI** and **saving compute resources** 🌱 (see below for quantity).

### Example
Here is an example of the behaviour described above: the commit [`1965ed0`](https://github.com/pulp-platform/snitch_cluster/commit/1965ed07d59e421a69594cb7134ea5f120c334d4) changed these files: `docs/ug/trace_analysis.md` and, when pushed, triggered [this](https://github.com/pulp-platform/snitch_cluster/actions/runs/9551200132) workflow run, which ran for ~56 CPU minutes. With the proposed changes, these 56 CPU minutes would have been saved, clearing the queue for other workflows and speeding up the CI of the project, while also saving resources in general. 

Note that this is a single example out of 11 examples over the last few months; a lower estimate for the accumulated gain is **7 CPU hours**, but the actual number could be higher because our cutoff date is late May and our data go only a few months back.

<details>
<summary>Click here to see all the recent CI runs triggered by markdown files.</summary>

[commit 1965ed0](https://github.com/pulp-platform/snitch_cluster/commit/1965ed0) => [run url](https://github.com/pulp-platform/snitch_cluster/actions/runs/9551200132)
[commit 37b17a6](https://github.com/pulp-platform/snitch_cluster/commit/37b17a6) => [run url](https://github.com/pulp-platform/snitch_cluster/actions/runs/9303101757)
[commit be2f2c7](https://github.com/pulp-platform/snitch_cluster/commit/be2f2c7) => [run url](https://github.com/pulp-platform/snitch_cluster/actions/runs/9463531902)
[commit 340140f](https://github.com/pulp-platform/snitch_cluster/commit/340140f) => [run url](https://github.com/pulp-platform/snitch_cluster/actions/runs/14085115690)
[commit 6e85387](https://github.com/pulp-platform/snitch_cluster/commit/6e85387) => [run url](https://github.com/pulp-platform/snitch_cluster/actions/runs/12434213510)
[commit dd15096](https://github.com/pulp-platform/snitch_cluster/commit/dd15096) => [run url](https://github.com/pulp-platform/snitch_cluster/actions/runs/14135659152)
[commit 24a4289](https://github.com/pulp-platform/snitch_cluster/commit/24a4289) => [run url](https://github.com/pulp-platform/snitch_cluster/actions/runs/14138972379)
[commit 5bf6754](https://github.com/pulp-platform/snitch_cluster/commit/5bf6754) => [run url](https://github.com/pulp-platform/snitch_cluster/actions/runs/14087112318)
[commit 4381f44](https://github.com/pulp-platform/snitch_cluster/commit/4381f44) => [run url](https://github.com/pulp-platform/snitch_cluster/actions/runs/10723692001)
[commit 82f6988](https://github.com/pulp-platform/snitch_cluster/commit/82f6988) => [run url](https://github.com/pulp-platform/snitch_cluster/actions/runs/14135721036)
[commit c4c036a](https://github.com/pulp-platform/snitch_cluster/commit/c4c036a) => [run url](https://github.com/pulp-platform/snitch_cluster/actions/runs/14137568940)

</details>

### Context
Hi,

We are a team of [researchers](https://www.ifi.uzh.ch/en/zest.html) from University of Zurich and we are currently working on optimizations in GitHub Actions workflows.

Thanks for your time on this.

Kindly let us know (here or in the email below) if you would like to ignore other file types or apply the filter to other workflows/triggers, or if you have any question whatsoever.

Best regards,  
[Konstantinos Kitsios](https://www.ifi.uzh.ch/en/zest/team/konstantinos_kitsios.html)  
konstantinos.kitsios@uzh.ch