### PR TITLE
hw: Fix bug in reqrsp_to_axi_intf parameters

### DIFF
--- a/hw/reqrsp_interface/src/reqrsp_to_axi.sv
+++ b/hw/reqrsp_interface/src/reqrsp_to_axi.sv
@@ -340,6 +340,7 @@ module reqrsp_to_axi_intf #(
 
   reqrsp_to_axi #(
     .DataWidth ( DataWidth ),
+    .UserWidth ( AxiUserWidth ),
     .reqrsp_req_t (reqrsp_req_t),
     .reqrsp_rsp_t (reqrsp_rsp_t),
     .axi_req_t (axi_req_t),


### PR DESCRIPTION
The module `reqrsp_to_axi_intf` takes a `AxiUserWidth` parameter but does not pass it to the instance of `reqrsp_to_axi`. Therefore `reqrsp_to_axi.UserWidth` defaults to 0 and the input port `reqrsp_to_axi.user_i` becomes always a 2-bit array indexed as `[-1:0]`. This can create indexing errors and port size mismatches.
This PR fixes this issue.