### PR TITLE
Fix roi target

### DIFF
--- a/target/common/common.mk
+++ b/target/common/common.mk
@@ -178,7 +178,7 @@ $(JOINT_PERF_DUMP): $(PERF_DUMPS) $(JOIN_PY)
 	$(JOIN_PY) -i $(shell ls $(LOGS_DIR)/*_perf.json) -o $@
 
 $(ROI_DUMP): $(JOINT_PERF_DUMP) $(ROI_SPEC) $(ROI_PY)
-	$(ROI_PY) $(JOINT_PERF_DUMP) $(ROI_SPEC) --cfg $(CFG) -o $@
+	$(ROI_PY) $(JOINT_PERF_DUMP) $(ROI_SPEC) --cfg $(SN_CFG) -o $@
 
 $(VISUAL_TRACE): $(ROI_DUMP) $(VISUALIZE_PY)
 	$(VISUALIZE_PY) $(ROI_DUMP) $(VISUALIZE_PY_FLAGS) -o $@

--- a/target/snitch_cluster/util/build.py
+++ b/target/snitch_cluster/util/build.py
@@ -118,7 +118,7 @@ def build_visual_trace(run_dir, roi_spec, hw_cfg=None):
         'ROI_SPEC': roi_spec
     }
     if hw_cfg is not None:
-        vars['CFG'] = hw_cfg
+        vars['SN_CFG'] = hw_cfg
     flags = ['-j']
     common.make('visual-trace', vars, flags=flags)
 


### PR DESCRIPTION
The ROI make target used the old `CFG` variable to pass the current hardware configuration.
It seems that this variable has been renamed to `SN_CFG`