### PR TITLE
Replace non-synthesizable code in `snitch_cluster.sv`

### DIFF
--- a/hw/snitch_cluster/src/snitch_cluster.sv
+++ b/hw/snitch_cluster/src/snitch_cluster.sv
@@ -659,7 +659,9 @@ module snitch_cluster
   );
 
 
-  logic [WideSlaveIdxBits-1:0] dma_xbar_default_port = SoCDMAOut;
+  logic [WideSlaveIdxBits-1:0] dma_xbar_default_port;
+  assign dma_xbar_default_port = SoCDMAOut;
+
   xbar_rule_t dma_xbar_default_port_rule;
   assign dma_xbar_default_port_rule = '{
     idx: dma_xbar_default_port,


### PR DESCRIPTION
In `cluster_tile.sv` the `dma_xbar_default_port ` variable is currently assigned on declaration, causing incorrect behaviors during synthesis.
This PR fixes the issue.