### PR TITLE
.gitmodules: use HTTPS instead of SSH

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,12 +1,12 @@
 [submodule "sw/deps/riscv-opcodes"]
 	path = sw/deps/riscv-opcodes
-	url = git@github.com:pulp-platform/riscv-opcodes.git
+	url = https://github.com/pulp-platform/riscv-opcodes.git
 [submodule "sw/deps/printf"]
 	path = sw/deps/printf
 	url = https://github.com/mpaland/printf.git
 [submodule "sw/deps/riscv-tests"]
 	path = sw/deps/riscv-tests
-	url = git@github.com:riscv-software-src/riscv-tests.git
+	url = https://github.com/riscv-software-src/riscv-tests.git
 [submodule "target/asic/ihp13/pdk"]
 	path = target/asic/ihp13/pdk
-	url = git@github.com:IHP-GmbH/IHP-Open-PDK.git
+	url = https://github.com/IHP-GmbH/IHP-Open-PDK.git


### PR DESCRIPTION
Using SSH for git submodules only works if an SSH key is registered with Github. This is not the case for Github CI runners however. Using HTTPS solves this problem since it does not require any authentification for open-source repositories.

Note: The (arguably worse) alternative is to configure `url."https://github.com/".insteadOf "git@github.com:` in git, which is apparently also done behind the scenes when using the `checkout` action with `recursive` enabled.