### PR TITLE
Add IPC wait for simulator completion and make CI jobs conditional

### DIFF
--- a/.github/actions/setup-python/action.yml
+++ b/.github/actions/setup-python/action.yml
@@ -8,6 +8,14 @@ description: Install Python dependencies once per job, and cache across jobs
 runs:
   using: "composite"
   steps:
+    # In containerized jobs, checkout is sometimes done by a different user
+    # than the one running subsequent steps (root, possibly due to Docker),
+    # which makes git refuse to operate on the repository.
+    - name: Git config safe.directory
+      shell: sh
+      run: |
+        git config --global --add safe.directory "$GITHUB_WORKSPACE"
+
     # Cache the venv directory (fast subsequent jobs on same lockfile and Python version)
     - name: Cache venv
       uses: actions/cache@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,33 @@ concurrency:
 
 jobs:
 
+  #############
+  # Base SHA  #
+  #############
+
+  base-sha:
+    name: Determine base SHA
+    runs-on: ubuntu-22.04
+    outputs:
+      sha: ${{ steps.base-sha.outputs.sha }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Determine base SHA
+        id: base-sha
+        # Compare against the merge-base with `main`, not just the previous
+        # commit on this branch: CI doesn't necessarily run on every push
+        # (e.g. superseded runs get cancelled), so a plain previous-commit
+        # diff could silently skip over a real prerequisite change.
+        run: |
+          if [ "${{ github.ref_name }}" = "main" ]; then
+            echo "sha=${{ github.event.before }}" >> "$GITHUB_OUTPUT"
+          else
+            git fetch origin main
+            echo "sha=$(git merge-base origin/main HEAD)" >> "$GITHUB_OUTPUT"
+          fi
+
   ##########################
   # Build Docker Container #
   ##########################
@@ -252,7 +279,7 @@ jobs:
   synthesis:
     name: Synthesis w/ Yosys
     runs-on: ubuntu-22.04
-    needs: [docker-meta, build-hw-image]
+    needs: [docker-meta, build-hw-image, base-sha]
     container:
       image: ${{ needs.docker-meta.outputs.hw_image_name }}
       volumes:
@@ -272,6 +299,7 @@ jobs:
         with:
           target: yosys
           flags: --recursive
+          base_sha: ${{ needs.base-sha.outputs.sha }}
       - name: Run Synthesis
         if: steps.make-prerequisites-changed.outputs.changed == 'true'
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -154,16 +154,17 @@ jobs:
           submodules: 'recursive'
       - uses: ./.github/actions/setup-python
       - name: Hash Verilator prerequisites
-        id: verilator-hash
-        run: |
-          hash=$(list-make-prerequisites verilator --recursive --hash)
-          echo "hash=$hash" >> "$GITHUB_OUTPUT"
+        id: list-make-prerequisites
+        uses: colluca/list-make-prerequisites@v1.0.0
+        with:
+          target: verilator
+          flags: --recursive
       - name: Set up cache for Verilator build
         id: verilator-cache
         uses: actions/cache@v4
         with:
           path: target/sim/build/bin
-          key: verilator-${{ steps.verilator-hash.outputs.hash }}
+          key: verilator-${{ steps.list-make-prerequisites.outputs.hash }}
           restore-keys: |
             verilator-
       - name: Build Hardware
@@ -218,17 +219,18 @@ jobs:
           submodules: 'recursive'
       - uses: ./.github/actions/setup-python
       - name: Hash Verilator prerequisites
-        id: verilator-hash
-        run: |
-          hash=$(list-make-prerequisites verilator --recursive --hash)
-          echo "hash=$hash" >> "$GITHUB_OUTPUT"
+        id: list-make-prerequisites
+        uses: colluca/list-make-prerequisites@v1.0.0
+        with:
+          target: verilator
+          flags: --recursive
       - name: Set up cache for Verilator build
         id: verilator-cache
         uses: actions/cache@v4
         with:
           path: |
             /repo/target/sim/build/bin
-          key: verilator-mempool-${{ steps.verilator-hash.outputs.hash }}
+          key: verilator-mempool-${{ steps.list-make-prerequisites.outputs.hash }}
           restore-keys: |
             verilator-mempool-
       - name: Build Hardware
@@ -268,8 +270,16 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: 'recursive'
+          fetch-depth: 0
       - uses: ./.github/actions/setup-python
+      - name: Check if Yosys prerequisites changed
+        id: make-prerequisites-changed
+        uses: colluca/make-prerequisites-changed@v1.0.0
+        with:
+          target: yosys
+          flags: --recursive
       - name: Run Synthesis
+        if: steps.make-prerequisites-changed.outputs.changed == 'true'
         run: |
           make CFG_OVERRIDE=cfg/yosys-ci.json yosys
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,12 +107,6 @@ jobs:
         with:
           submodules: 'recursive'
       - uses: ./.github/actions/setup-python
-      # For some reason, the checkout is done by a different user
-      # than that deploying to Github (root, possibly due to Docker).
-      # So we need to set the repository as a safe directory.
-      - name: Git config safe.directory
-        run: |
-          git config --global --add safe.directory $GITHUB_WORKSPACE
       - name: Generate documentation sources
         run: |
           make doc-srcs
@@ -309,12 +303,6 @@ jobs:
       - name: Generate RTL sources
         run: |
           make rtl
-      # For some reason, the checkout is done by a different user,
-      # than that running `git diff` (root, possibly due to Docker).
-      # So we need to set the repository as a safe directory.
-      - name: Git config safe.directory
-        run: |
-          git config --global --add safe.directory $GITHUB_WORKSPACE
       - name: Diff porcelain
         uses: mmontes11/diff-porcelain@v0.0.1
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -268,7 +268,7 @@ jobs:
       - uses: ./.github/actions/setup-python
       - name: Check if Yosys prerequisites changed
         id: make-prerequisites-changed
-        uses: colluca/make-prerequisites-changed@v1.0.0
+        uses: colluca/make-prerequisites-changed@v1.1.1
         with:
           target: yosys
           flags: --recursive

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -12,11 +12,45 @@ variables:
   LLVM_SYS_120_PREFIX: /usr/pack/llvm-12.0.1-af
   CMAKE: cmake-3.18.1
 
+##########
+# Common #
+##########
+
 default:
   # Allow interrupting long-running jobs when a new pipeline on the same branch is triggered
   interruptible: true
   before_script:
     - source iis-setup.sh
+
+# Reusable guard that skips a job when MAKE_TARGET's prerequisites haven't
+# changed w.r.t. main. Usage: extend this job and `!reference` its script
+# before the real one; MAKE_TARGET defaults to the job name.
+.skip-if-unchanged:
+  variables:
+    MAKE_TARGET: $CI_JOB_NAME
+  script:
+    - |
+      if [ "$CI_COMMIT_REF_NAME" = "main" ]; then
+        BASE_SHA=$CI_COMMIT_BEFORE_SHA
+      else
+        git fetch origin main
+        BASE_SHA=$(git merge-base origin/main HEAD)
+      fi
+    - CHANGED=$(git diff --name-only $BASE_SHA HEAD | sed "s|^|$CI_PROJECT_DIR/|")
+    - PREREQS=$(list-make-prerequisites $MAKE_TARGET --recursive)
+    # Turn `CHANGED` into a regex to match entire directories (e.g. submodules) against
+    # individual files in `PREREQS`.
+    - |
+      CHANGED_PATTERN=$(sed -E 's/[.[\*^$()+?{}|]/\\&/g; s#^#^#; s#$#($|/)#' <<< "$CHANGED")
+    - TRIGGERS=$(grep -E -f <(printf '%s\n' "$CHANGED_PATTERN") <<< "$PREREQS" || true)
+    - |
+      if [ -n "$TRIGGERS" ]; then
+        echo "Running '$MAKE_TARGET': prerequisites changed since $BASE_SHA:"
+        echo "$TRIGGERS" | sed 's/^/  /'
+      else
+        echo "Skipping '$MAKE_TARGET': no prerequisites changed since $BASE_SHA"
+        exit 0
+      fi
 
 ##############
 # Build docs #
@@ -179,9 +213,11 @@ snitch-cluster-copift-sc-vsim:
 # Open-source implementation flow #
 ###################################
 
-yosys-synthesis:
+yosys:
   timeout: 4h
+  extends: .skip-if-unchanged
   script:
+    - !reference [.skip-if-unchanged, script]
     - make CFG_OVERRIDE=cfg/yosys-ci.json yosys
     # Following steps are not included in open-source CI since netlist
     # compilation with Verilator takes an excessive amount of time and memory.
@@ -195,5 +231,7 @@ yosys-synthesis:
 
 # Non-free elaboration flow
 elab:
+  extends: .skip-if-unchanged
   script:
+    - !reference [.skip-if-unchanged, script]
     - make elab

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -200,13 +200,18 @@ snitch-cluster-frep-vsim:
     - cd test
     - ../util/experiments/run.py frep_xs.yaml --simulator vsim -j --run-dir runs/vsim
 
-# COPIFT and scalar chaining experiments
-snitch-cluster-copift-sc-vsim:
+# COPIFT experiments
+snitch-cluster-copift-vsim:
   script:
     - make CFG_OVERRIDE=experiments/copift/cfg.json vsim -j
     - cd experiments/copift
     - ./experiments.py experiments.yaml --actions sw run perf -j
-    - cd ../chaining
+
+# Scalar chaining experiments
+snitch-cluster-chaining-vsim:
+  script:
+    - make CFG_OVERRIDE=experiments/copift/cfg.json vsim -j
+    - cd experiments/chaining
     - ./experiments.py experiments.yaml --actions sw run perf -j
 
 ###################################

--- a/make/common.mk
+++ b/make/common.mk
@@ -106,8 +106,9 @@ endef
 # Arg 3: bender arguments
 # Arg 4: top module name
 # Arg 5: name of target for which prerequisites are generated
+# Arg 6: additional prerequisites to generate Bender filelist
 define sn_gen_rtl_prerequisites
-$(2)/$(4).f: $(SN_BENDER_YML) $(SN_BENDER_LOCK) $(SN_GEN_RTL_SRCS) | $(2)
+$(2)/$(4).f: $(SN_BENDER_YML) $(SN_BENDER_LOCK) $(SN_GEN_RTL_SRCS) $(6) | $(2)
 	$(SN_BENDER) script verilator $(3) > $$@
 
 $(1): $(2)/$(4).f $(SN_GEN_RTL_SRCS) | $(2)

--- a/target/sim/tb/ipc.cc
+++ b/target/sim/tb/ipc.cc
@@ -58,29 +58,28 @@ void* IpcIface::ipc_thread_handle(void* in) {
                     fread(buf_data, op.len, 1, tx);
                     sim::MEM.write(op.addr, op.len, buf_data, buf_strb);
                     break;
-                case Poll:
-                    // Unpack 32b checking mask and expected value from length
-                    uint32_t mask = op.len & 0xFFFFFFFF;
-                    uint32_t expected = (op.len >> 32) & 0xFFFFFFFF;
-                    printf("[IPC] Poll on 0x%x mask 0x%x expected 0x%x ...\n",
-                           op.addr, mask, expected);
-                    uint32_t read;
-                    do {
-                        sim::MEM.read(op.addr, sizeof(uint32_t),
-                                      (uint8_t*)(void*)&read);
+                case Wait:
+                    // Block until the simulation has finished, then send back
+                    // its exit code. `finished` is set by `notify_finished()`
+                    // when the fesvr/HTIF run loop returns.
+                    printf("[IPC] Wait for simulation to finish ...\n");
+                    while (!targs->finished->load()) {
                         nanosleep(
-                            (const struct timespec[]){{0, IPC_POLL_PERIOD_NS}},
+                            (const struct timespec[]){{0, IPC_WAIT_PERIOD_NS}},
                             NULL);
-                    } while ((read & mask) == (expected & mask));
-                    // Send back read 32b word
-                    fwrite(&read, sizeof(uint32_t), 1, rx);
+                    }
+                    uint32_t exit_code = (uint32_t)targs->exit_code->load();
+                    fwrite(&exit_code, sizeof(uint32_t), 1, rx);
                     fflush(rx);
                     break;
             }
         }
     }
 
-    // TX FIFO closed at other end: close both FIFOs and join main thread
+    // TX FIFO closed at other end: the host has finished issuing commands.
+    // Signal this so the main thread stops evaluating the RTL, then close both
+    // FIFOs and join the main thread.
+    targs->disconnected->store(true);
     fclose(tx);
     fclose(rx);
     pthread_exit(NULL);
@@ -106,12 +105,25 @@ IpcIface::IpcIface(int argc, char** argv) {
             targs.rx = (char*)malloc(strlen(rx) + 1);
             strcpy(targs.tx, tx);
             strcpy(targs.rx, rx);
+            targs.finished = &finished;
+            targs.exit_code = &exit_code;
+            targs.disconnected = &disconnected;
             // Initialize IO thread which will handle TX, RX pipes
             pthread_create(&thread, NULL, *ipc_thread_handle, (void*)&targs);
             printf("[IPC] Thread launched with TX FIFO `%s`, RX FIFO `%s`\n",
                    targs.tx, targs.rx);
             active = true;
         }
+    }
+}
+
+// Notify the IPC thread that the simulation has finished.
+void IpcIface::notify_finished(int ec) {
+    if (active) {
+        // Store the exit code before setting `finished`, so it is visible to
+        // the IPC thread as soon as the flag is observed.
+        exit_code.store(ec);
+        finished.store(true);
     }
 }
 

--- a/target/sim/tb/ipc.hh
+++ b/target/sim/tb/ipc.hh
@@ -14,19 +14,21 @@
 #include <time.h>
 
 #include <algorithm>
+#include <atomic>
 
 class IpcIface {
    private:
     static const int IPC_BUF_SIZE = 4096;
     static const int IPC_BUF_SIZE_STRB = IPC_BUF_SIZE / 8 + 1;
     static const int IPC_ERR_DOUBLE_ARG = 30;
-    static const long IPC_POLL_PERIOD_NS = 100000L;
+    static const long IPC_WAIT_PERIOD_NS = 100000L;
 
     // Possible IPC operations
     enum ipc_opcode_e {
         Read = 0,
         Write = 1,
-        Poll = 2,
+        // Block until the simulation has finished, then return its exit code.
+        Wait = 2,
     };
 
     // Operations are 3 doubles, followed by data streams in either direction
@@ -40,16 +42,42 @@ class IpcIface {
     typedef struct {
         char* tx;
         char* rx;
+        // Set once the simulation has finished, to release a pending `Wait`
+        // command. See `notify_finished()`.
+        std::atomic<bool>* finished;
+        // The simulation exit code, valid once `finished` is set. Returned to
+        // the host by a `Wait` command.
+        std::atomic<int>* exit_code;
+        // Set by the IPC thread once the host closes the TX FIFO, i.e. once it
+        // has finished issuing commands (see `session_open()`).
+        std::atomic<bool>* disconnected;
     } ipc_targs_t;
 
     // Thread to asynchronously handle FIFOs
     ipc_targs_t targs;
     pthread_t thread;
     bool active;
+    // Signals the IPC thread that the simulation has terminated, and the
+    // corresponding exit code (valid once `finished` is set).
+    std::atomic<bool> finished{false};
+    std::atomic<int> exit_code{0};
+    // Set by the IPC thread once the host has disconnected (closed TX).
+    std::atomic<bool> disconnected{false};
 
     static void* ipc_thread_handle(void* in);
 
    public:
     IpcIface(int argc, char** argv);
     ~IpcIface();
+
+    // Notify the IPC thread that the simulation has finished, with the given
+    // exit code. This releases a pending `Wait` command, which the host uses
+    // to detect end-of-simulation.
+    void notify_finished(int exit_code);
+
+    // Whether an IPC session is active and the host has not disconnected yet.
+    // The testbench keeps evaluating the RTL while this holds, so that memory
+    // writes still in flight when the program exits drain to the global memory
+    // before the host reads them back. Returns false when IPC is not in use.
+    bool session_open() const { return active && !disconnected.load(); }
 };

--- a/target/sim/tb/rtl_lib.cc
+++ b/target/sim/tb/rtl_lib.cc
@@ -44,12 +44,21 @@ void Sim::idle() { host->switch_to(); }
 int Sim::run() {
     host = context_t::current();
     target.switch_to();
+    // While an IPC host is connected, keep the testbench ticking (report "not
+    // done") even after the program has exited, so memory writes still in
+    // flight drain and the host can read back committed results. Report the
+    // real exit status only once the host disconnects.
+    if (ipc.session_open()) return 0;
     return (exit_code() << 1 | done());
 }
 
 // Host thread.
 void Sim::main() {
-    htif_t::run();
+    int exit_code = htif_t::run();
+    // HTIF has finished: release the IPC thread's pending `Wait` command (and
+    // hand it the exit code) so the host-side verification script can detect
+    // completion.
+    ipc.notify_finished(exit_code);
     // HTIF has finished, just idle now.
     while (true) {
         idle();

--- a/target/sim/tb/verilator_lib.cc
+++ b/target/sim/tb/verilator_lib.cc
@@ -44,7 +44,20 @@ void Sim::idle() { target.switch_to(); }
 int Sim::run() {
     host = context_t::current();
     target.init(sim_thread_main, this);
-    return htif_t::run();
+    int exit_code = htif_t::run();
+    // The program has signalled end-of-computation (fesvr/HTIF observed the
+    // `tohost` write), but memory writes it issued just before exiting may
+    // still be in flight in the interconnect and not yet committed to the
+    // global memory. Release the host's pending `Wait` command so it can read
+    // back results, but keep evaluating the RTL until the host disconnects, so
+    // those writes drain and the read-back observes committed data. (Once the
+    // program has exited its cores are parked, so this just drains pending
+    // transactions and then idles.)
+    ipc.notify_finished(exit_code);
+    while (ipc.session_open() && !Verilated::gotFinish()) {
+        idle();
+    }
+    return exit_code;
 }
 
 void Sim::main() {

--- a/util/sim/SnitchSim.py
+++ b/util/sim/SnitchSim.py
@@ -91,15 +91,13 @@ class SnitchSim:
         self.tx.write(data)
 
     @__sim_active
-    def poll(self, addr: int, mask32: int, exp32: int):
-        op = struct.pack('=QQLL', 2, addr, mask32, exp32)
-        while True:
-            try:
-                self.tx.write(op)
-            except IOError:
-                print('Broken pipe error')
-                continue
-            break
+    def wait(self):
+        # Block until the simulation has finished, and return its exit code.
+        # The testbench replies only once the simulation terminates, so this
+        # doubles as an end-of-simulation barrier. The address/length fields
+        # are unused by this opcode but kept for a uniform message layout.
+        op = struct.pack('=QQQ', 2, 0, 0)
+        self.tx.write(op)
         bytestring = self.rx.read(4)
         return int.from_bytes(bytestring, byteorder='little')
 

--- a/util/sim/verif_utils.py
+++ b/util/sim/verif_utils.py
@@ -184,7 +184,7 @@ class Verifier:
         Spawns a subprocess to simulate the `snitch_bin` binary, using a
         command of the form `sim_bin snitch_bin <ipc_args>`. It
         communicates with the simulation using inter-process communication
-        (IPC) facilities, to poll the program for termination and retrieve
+        (IPC) facilities, to wait for the program to terminate and retrieve
         the memory contents where the results of the simulation are
         stored. The results of the simulation must have global symbols
         associated in `snitch_bin` in order to retrieve their address and
@@ -196,17 +196,13 @@ class Verifier:
         simulation, formatted as raw bytes. The dictionary is stored in
         the `self.raw_outputs` attribute.
         """
-        # Open ELF file for processing
-        elf = Elf(self.args.snitch_bin)
-
         # Start simulation
         sim = SnitchSim(self.args.sim_bin, self.args.snitch_bin, simulator=self.args.simulator,
                         log=self.args.log)
         sim.start()
 
         # Wait for kernel execution to be over
-        tohost = elf.get_symbol_address('tohost')
-        sim.poll(tohost, 1, 0)
+        sim.wait()
 
         # Read out results from memory
         output_locs = self.get_output_memory_locations()

--- a/uv.lock
+++ b/uv.lock
@@ -1617,14 +1617,14 @@ wheels = [
 
 [[package]]
 name = "pymakeutils"
-version = "1.4.0"
+version = "1.5.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anytree" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/90/f7/6b854a6e9f5012cbcb778d8eacf8d4497b5b55032982b444ca1255d4df66/pymakeutils-1.4.0.tar.gz", hash = "sha256:48cd5b7958a82a5cbb0ac44f1ea5200ecee382afa34535a4d375dc87c75b06f3", size = 15250, upload-time = "2025-09-29T12:55:24.452Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/bb/ff/0e2a6a69faa7f524da559c38ea395559e025ebb9827d109ebb68e4a99cb5/pymakeutils-1.5.0.tar.gz", hash = "sha256:2356b8ac0804a4f36c294bec73f4a5654ef1cd3a0dc15837013d6d71d4459a71", size = 16497, upload-time = "2026-07-27T13:27:20.511Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/68/f4/6a06822fe183455725b4ce1b73289176cf37d9dcd52280fa86688d6e86d3/pymakeutils-1.4.0-py3-none-any.whl", hash = "sha256:4c5685c3921d896a1087632a587d2c377f87fddf48d2c88f0f0127a1c227ed18", size = 13691, upload-time = "2025-09-29T12:55:23.118Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/0d/38bde112a164633497a0d7f8f23bf120cc88bad89fe8e173def2768346ee/pymakeutils-1.5.0-py3-none-any.whl", hash = "sha256:3ee35cc23f66b623cdef6ce76a0aaa9dd15995ab983c08ad782281e0389ad17a", size = 14096, upload-time = "2026-07-27T13:27:19.253Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- replace IPC polling with a wait command that returns the simulator exit code
- keep RTL simulation ticking while an IPC host remains connected so in-flight memory writes can drain
- update verification utilities to wait for simulation completion before reading outputs

## Auxiliary
- make long internal CI jobs conditional on prerequisite files having changed compared to main
- split COPIFT and chaining experiment jobs in CI for faster runtimes 
- bump cockpit in pd after GF12 technology changes
- configure git repo as safe in all containerized jobs

## Why this is needed
The previous verification flow had a race on the `tohost` word between fesvr/HTIF and the IPC poller. Both agents watched the same address in `sim::MEM`: HTIF polls `tohost` to detect program exit, while `verif_utils.py` asked the IPC thread to poll the same word until bit 0 became set.

The problem is that HTIF is a destructive reader of `tohost`. Once it observes the exit write, it immediately clears `tohost` back to zero while processing the command. The target program writes `tohost = (retcode << 1) | 1` only once at exit, so the visible `bit0 = 1` state can be extremely short lived.

If the asynchronous IPC polling thread misses that short window, it reads the HTIF-cleared zero and keeps waiting for `tohost & 1` to become nonzero. But HTIF has already returned, the RTL clock has stopped, and the program will never write `tohost` again. That leaves the simulator alive but stuck: the IPC thread sleeps and polls forever, the Python verifier blocks on `rx.read(4)`, and simulator teardown waits for the IPC thread to finish.

This showed up primarily in CI because the IPC poll loop slept between samples. On an idle local machine it often sampled frequently enough to catch the `tohost` transition, but under heavy CI load the sleep and scheduling delay could stretch long enough to reliably miss the tiny HTIF-cleared window.

This PR stops sharing the destructive `tohost` signal with the IPC poller. Instead, the simulator notifies IPC when HTIF has finished, the host waits on that explicit completion signal, and the RTL keeps ticking while the IPC session remains open so in-flight memory writes can drain before the verifier reads back results.