### PR TITLE
hw: gate the per-instruction trace behind `ifdef DEBUG

### DIFF
--- a/hw/snitch_cluster/src/snitch_cc.sv
+++ b/hw/snitch_cluster/src/snitch_cc.sv
@@ -850,6 +850,7 @@ module snitch_cc #(
   ////////////
 
   // pragma translate_off
+`ifdef DEBUG
   int f;
   string fn;
   logic [63:0] cycle;
@@ -993,6 +994,7 @@ module snitch_cc #(
     $fclose(f);
   end
   // verilog_lint: waive-stop always-ff-non-blocking
+`endif
   // pragma translate_on
 
   ////////////////

--- a/make/common.mk
+++ b/make/common.mk
@@ -56,6 +56,9 @@ SN_BENDER_YML  = $(SN_ROOT)/Bender.yml
 # Flags
 SN_COMMON_BENDER_FLAGS      += -t rtl -t cc_no_deprecated -t tech_cells_generic_include_tc_sync
 SN_COMMON_BENDER_SIM_FLAGS  += $(SN_COMMON_BENDER_FLAGS) -t test -t snitch_cluster:tb
+ifeq ($(DEBUG),ON)
+SN_COMMON_BENDER_SIM_FLAGS  += -DDEBUG
+endif
 SN_COMMON_BENDER_ASIC_FLAGS += $(SN_COMMON_BENDER_FLAGS) -t asic
 SN_LAYOUT_EVENTS_FLAGS      ?= --cfg=$(SN_CFG)
 


### PR DESCRIPTION
The `snitch_cc` `.dasm` tracer opens `logs/trace_hart_*.dasm` and `$fwrite`s a
line per retired instruction unconditionally (guarded only by `translate_off`),
for every hart in the design. On a multi-cluster sim that is 100+ harts each
doing a per-cycle `$sformat` + `$fwrite` to disk, which dominates wall-clock
during compute and writes hundreds of MB per run even when the trace is unwanted.

Fully gate the tracer behind `ifdef DEBUG