### PR TITLE
hw: gate the iDMA tracer behind the DEBUG define

### DIFF
--- a/hw/snitch_cluster/src/snitch_cc.sv
+++ b/hw/snitch_cluster/src/snitch_cc.sv
@@ -349,6 +349,11 @@ module snitch_cc #(
   /////////
 
   if (IsaCfg.Xdma) begin : gen_dma
+`ifdef TRACE_OFF
+    localparam bit DMATrace = 1'b0;
+`else
+    localparam bit DMATrace = 1'b1;
+`endif
     idma_inst64_top #(
       .AxiAddrWidth (AddrWidth),
       .AxiDataWidth (DMADataWidth),
@@ -357,7 +362,7 @@ module snitch_cc #(
       .NumAxInFlight (DMANumAxInFlight),
       .DMAReqFifoDepth (DMAReqFifoDepth),
       .NumChannels (DMANumChannels),
-      .DMATracing (1),
+      .DMATracing (DMATrace),
       .axi_ar_chan_t (axi_ar_chan_t),
       .axi_aw_chan_t (axi_aw_chan_t),
       .axi_req_t (axi_req_t),

--- a/make/verilator.mk
+++ b/make/verilator.mk
@@ -19,6 +19,9 @@ SN_VLT_FESVR    = $(SN_VLT_BUILDDIR)/riscv-isa-sim
 
 # Flags
 SN_VLT_BENDER_FLAGS += $(SN_COMMON_BENDER_FLAGS) -t snitch_cluster:tb -t verilator -DASSERTS_OFF
+ifeq ($(TRACE), OFF)
+SN_VLT_BENDER_FLAGS += -DTRACE_OFF
+endif
 SN_VLT_FLAGS += --timing
 SN_VLT_FLAGS += --timescale 1ns/1ps
 SN_VLT_FLAGS += --trace-vcd


### PR DESCRIPTION
Follows up on #328 and coordinates with @colluca's upcoming `TRACE` change.

`idma_inst64_top` was instantiated with a hardcoded `.DMATracing (1)`, so the iDMA backend wrote `dma_trace_*.log` on every run. Rather than couple this to `DEBUG` (which also pulls in `+acc` and slows the sim), it now follows the same `TRACE` opt-out being introduced for the `snitch_cc` trace: **traces on by default, `TRACE=OFF` disables them**.

Two commits:

- **`hw: gate the iDMA tracer with the TRACE_OFF opt-out`** - `idma_inst64_top` derives `.DMATracing` from a local `DMATrace` parameter gated by `` `ifndef TRACE_OFF ``, so the iDMA trace is silenced together with the `snitch_cc` trace under `TRACE=OFF`.
- **`make: wire the TRACE_OFF opt-out into the Verilator flow`** - the trace define reaches only the vsim bender flags; Verilator builds from the base flags. This adds the `TRACE=OFF -> -DTRACE_OFF` guard to `SN_VLT_BENDER_FLAGS` so the opt-out works under Verilator too.

### Coordination with the `TRACE` change

`DMATracing` is an elaboration-time **parameter**, so `TRACE_OFF` has to be a **compile** define (bender `-DTRACE_OFF` / `--vlog-arg`), not just a `+define` on the `vsim` run command. `SN_VSIM_FLAGS` feeds the `vsim` simulate step (`vsim.mk:103/110`), while `SN_VLOG_FLAGS`/bender feed the compile step (`vsim.mk:90`), so a `+define+TRACE_OFF` on `SN_VSIM_FLAGS` alone would not reach either the `snitch_cc` `` `ifndef `` or this parameter. This PR handles the Verilator wiring; the vsim compile-side wiring belongs with the `TRACE` change.

### Verified (iDMA side, self-contained on Verilator)

`dma_1d` on Verilator: default build -> iDMA `dma_trace_*.log` present; `TRACE=OFF` build -> absent. (The `snitch_cc` `.dasm` trace stays on the old `DEBUG` gate until the `TRACE` change lands, so it reads 0 in both cases here; it will follow `TRACE_OFF` once that lands.)

Draft until the `TRACE` change lands; will rebase and re-run the full on/off smoke-check on both flows then.
