### PR TITLE
chore: Spyglass fpnew fix

### DIFF
--- a/Bender.lock
+++ b/Bender.lock
@@ -73,7 +73,7 @@ packages:
     dependencies:
     - common_cells
   fpnew:
-    revision: 45f273e95ccc5123a2c3d4d02c9b62f73385fd8f
+    revision: 1c20ab091efdf7e6784d4d652459eb3cfd883fae
     version: null
     source:
       Git: https://github.com/pulp-platform/cvfpu.git


### PR DESCRIPTION
Bump the Fpnew version: reintroduced a lost commit from the `common-cells-v2` [branch](https://github.com/pulp-platform/cvfpu/commit/46cb33a4ce6b04b83ec38ebd288dd58a031a6390). 